### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in metadata generator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,7 @@
 2. Verify path containment within allowed boundaries using `is_relative_to` (or `security_utils.validate_path_within_base`).
 3. For endpoints invoking system commands with user-provided paths, ensure paths are absolute to prevent them from being parsed as options (flags starting with `-`), or explicitly block paths where `.name.startswith('-')`.
 4. Special care must be given to URL support to prevent bypasses like `file:///etc/passwd` when filtering `http`/`https`.
+## 2024-05-31 - SQL Injection via Unvalidated Column Names
+**Vulnerability:** The `save_file_metadata` method in `metadata_generator.py` dynamically constructed SQL `INSERT` statements using raw dictionary keys from the `metadata` argument without validation, enabling severe SQL injection if user-provided data was used as keys.
+**Learning:** Directly interpolating map/dictionary keys into dynamic SQL commands for column names bypasses standard parameterization protection. This is a critical risk when dynamically inserting structured or arbitrary JSON payload keys into databases.
+**Prevention:** Always maintain a strict allowlist (schema definition) of valid column names and filter incoming data keys against this allowlist *before* constructing dynamic SQL statements, ensuring untrusted strings are never executed as database commands.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -465,11 +465,34 @@ class MetadataGenerator:
     def save_file_metadata(self, metadata: Dict[str, Any]) -> bool:
         """Save file metadata to database"""
         
+        # Valid columns from database schema to prevent SQL injection
+        valid_columns = {
+            'id', 'file_path', 'file_name', 'file_extension', 'file_size', 'file_type',
+            'created_date', 'modified_date', 'indexed_date', 'ai_category', 'ai_subcategory',
+            'confidence_score', 'classification_method', 'content_preview', 'content_length',
+            'word_count', 'page_count', 'people_mentioned', 'organizations', 'dates_mentioned',
+            'project_codes', 'auto_tags', 'user_tags', 'original_location', 'organized_location',
+            'enhanced_filename', 'organization_status', 'gdrive_upload', 'gdrive_folder',
+            'gdrive_file_id', 'gdrive_category', 'gdrive_confidence', 'upload_timestamp',
+            'space_freed_mb', 'duration_seconds', 'audio_bitrate', 'video_resolution',
+            'processing_mode', 'questions_asked', 'user_corrections', 'last_updated'
+        }
+
         try:
             with sqlite3.connect(self.db_path) as conn:
-                # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                # Convert to database format with strict column validation
+                columns = []
+                values = []
+
+                for k, v in metadata.items():
+                    if k in valid_columns:
+                        columns.append(k)
+                        values.append(v)
+
+                if not columns:
+                    print("Error: No valid columns provided for metadata")
+                    return False
+
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `save_file_metadata` method constructed SQL `INSERT` statements using raw dictionary keys from the `metadata` argument without validation, enabling severe SQL injection if user-provided data was used as keys.
🎯 **Impact:** An attacker could craft a payload with malicious keys (e.g., `{"category) VALUES (1); DROP TABLE file_metadata; --": "value"}`) to execute arbitrary SQL commands.
🔧 **Fix:** Introduced an explicit `valid_columns` allowlist matching the table schema. The method now filters incoming `metadata` keys against this allowlist *before* constructing the dynamic SQL statement.
✅ **Verification:** Verified by code review and ensuring valid schema logic aligns with DB definitions.

---
*PR created automatically by Jules for task [12106784635081920666](https://jules.google.com/task/12106784635081920666) started by @thebearwithabite*