### PR TITLE
🎨 Palette: Make JSON Sidecar accordion accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## $(date +%Y-%m-%d) - Accessible Accordion Details
+**Learning:** Native `useId` hooks paired with ARIA state logic (`aria-controls`, `aria-expanded`, `role="region"`) significantly improves interactive element accessibility by definitively linking disclosure buttons to their content region and explicitly defining states. Also applying explicit `focus-visible` outline styles ensures standard keyboard navigation does not feel invisible to screen readers or keyboard users.
+**Action:** Always link expandable regions to their buttons via standard ARIA pairs when using native JSX buttons instead of radix/headless components.

--- a/frontend_v2/src/components/triage/JsonSidecarViewer.tsx
+++ b/frontend_v2/src/components/triage/JsonSidecarViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useId } from 'react'
 import { FileJson, ChevronDown, ChevronRight } from 'lucide-react'
 
 interface JsonSidecarViewerProps {
@@ -10,6 +10,8 @@ export default function JsonSidecarViewer({ filePath }: JsonSidecarViewerProps) 
     const [isOpen, setIsOpen] = useState(false)
     const [isLoading, setIsLoading] = useState(false)
     const [exists, setExists] = useState(false)
+    const buttonId = useId()
+    const contentId = useId()
 
     // Sidecar path is usually original path + .json
     const sidecarPath = `${filePath}.json`
@@ -42,19 +44,31 @@ export default function JsonSidecarViewer({ filePath }: JsonSidecarViewerProps) 
     return (
         <div className="mt-4 border border-white/10 rounded-xl overflow-hidden bg-white/5">
             <button
+                id={buttonId}
                 onClick={() => setIsOpen(!isOpen)}
-                className="w-full px-4 py-3 flex items-center justify-between hover:bg-white/5 transition-colors"
+                aria-expanded={isOpen}
+                aria-controls={contentId}
+                className="w-full px-4 py-3 flex items-center justify-between hover:bg-white/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
             >
                 <div className="flex items-center gap-2 text-sm font-medium text-white/80">
-                    <FileJson size={16} className="text-yellow-400" />
+                    <FileJson size={16} className="text-yellow-400" aria-hidden="true" />
                     <span>Sidecar Metadata</span>
-                    {isLoading && <span className="text-xs text-white/40 ml-2">(Loading...)</span>}
+                    {isLoading && <span className="text-xs text-white/40 ml-2" aria-live="polite">(Loading...)</span>}
                 </div>
-                {isOpen ? <ChevronDown size={16} className="text-white/40" /> : <ChevronRight size={16} className="text-white/40" />}
+                {isOpen ? (
+                    <ChevronDown size={16} className="text-white/40" aria-hidden="true" />
+                ) : (
+                    <ChevronRight size={16} className="text-white/40" aria-hidden="true" />
+                )}
             </button>
 
             {isOpen && data && (
-                <div className="p-4 bg-black/20 border-t border-white/10 font-mono text-xs text-white/70 overflow-x-auto">
+                <div
+                    id={contentId}
+                    role="region"
+                    aria-labelledby={buttonId}
+                    className="p-4 bg-black/20 border-t border-white/10 font-mono text-xs text-white/70 overflow-x-auto"
+                >
                     <pre>{JSON.stringify(data, null, 2)}</pre>
                 </div>
             )}


### PR DESCRIPTION
💡 What: Added ARIA roles, `useId` linkings, and explicit focus states to the `JsonSidecarViewer.tsx` accordion component.
🎯 Why: Makes the native disclosure component fully accessible to screen readers by announcing expanded/collapsed states and defining relationships between the toggle and the content. Improves keyboard navigation with visible focus indicators.
📸 Before/After: Visual change introduces clear focus ring when navigating via keyboard. Screen readers now accurately read the disclosure state and linked content.
♿ Accessibility:
  - Added `aria-expanded` and `aria-controls` linked to generated unique `useId()` keys.
  - Set `role="region"` and `aria-labelledby` on the open content wrapper.
  - Added explicit `focus-visible` outline styles (`focus-visible:ring-2`, `focus-visible:ring-primary`, `focus-visible:outline-none`, `focus-visible:ring-inset`) for keyboard navigation.
  - Added `aria-hidden="true"` to decorative Lucide icons.
  - Added `aria-live="polite"` to the loading indicator text.

---
*PR created automatically by Jules for task [17434271630475725925](https://jules.google.com/task/17434271630475725925) started by @thebearwithabite*