### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in metadata generator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,10 @@
 2. Verify path containment within allowed boundaries using `is_relative_to` (or `security_utils.validate_path_within_base`).
 3. For endpoints invoking system commands with user-provided paths, ensure paths are absolute to prevent them from being parsed as options (flags starting with `-`), or explicitly block paths where `.name.startswith('-')`.
 4. Special care must be given to URL support to prevent bypasses like `file:///etc/passwd` when filtering `http`/`https`.
+## 2024-03-10 - SQL Injection via Dictionary Keys in Dynamic Inserts
+
+**Vulnerability:** The `MetadataGenerator.save_file_metadata()` method dynamically constructed `INSERT OR REPLACE` SQL queries by directly joining dictionary keys (`', '.join(columns)` where `columns = list(metadata.keys())`). This allowed an attacker to execute arbitrary SQL commands by passing a maliciously crafted key (e.g., `{"malicious_column) VALUES (1); DROP TABLE...": "value"}`).
+
+**Learning:** When using Python f-strings to build dynamic SQL queries (like inserting varying metadata fields), standard `?` parameterization only protects the *values*, not the *column names*. If the column names are derived from unsanitized input (like keys of an external dictionary), the system remains vulnerable to SQL injection.
+
+**Prevention:** Always validate and filter dynamic column names against an explicit schema allowlist. By fetching the valid columns from the database (e.g., via `PRAGMA table_info`) and filtering the incoming dictionary keys to only include those that match the known schema, we can completely eliminate the risk of SQL injection through dynamic field mapping.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -467,9 +467,19 @@ class MetadataGenerator:
         
         try:
             with sqlite3.connect(self.db_path) as conn:
-                # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                # Get valid columns to prevent SQL injection
+                cursor = conn.execute("PRAGMA table_info(file_metadata)")
+                valid_columns = {row[1] for row in cursor.fetchall()}
+
+                # Filter metadata to only include valid columns
+                filtered_metadata = {k: v for k, v in metadata.items() if k in valid_columns}
+
+                if not filtered_metadata:
+                    return False
+
+                # Convert to database format securely
+                columns = list(filtered_metadata.keys())
+                values = list(filtered_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 

--- a/tests/test_metadata_generator_sql_injection.py
+++ b/tests/test_metadata_generator_sql_injection.py
@@ -1,0 +1,43 @@
+import unittest
+import sqlite3
+import os
+from pathlib import Path
+from metadata_generator import MetadataGenerator
+
+class TestMetadataGeneratorSQLInjection(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path("/tmp/test_metadata_gen")
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+        self.generator = MetadataGenerator(base_dir=str(self.test_dir))
+        # Point the db to a test file
+        self.generator.db_path = self.test_dir / "test_metadata.db"
+        self.generator._init_tracking_db()
+
+    def tearDown(self):
+        if self.generator.db_path.exists():
+            self.generator.db_path.unlink()
+
+    def test_save_file_metadata_ignores_malicious_keys(self):
+        # Insert a record with malicious keys
+        malicious_metadata = {
+            'file_name': 'test.txt',
+            'file_path': '/tmp/test_metadata_gen/test.txt',
+            'malicious_col) VALUES (1); DROP TABLE file_metadata; --': 'value'
+        }
+
+        # Save metadata
+        result = self.generator.save_file_metadata(malicious_metadata)
+        self.assertTrue(result)
+
+        # Verify table still exists and data was inserted cleanly
+        with sqlite3.connect(self.generator.db_path) as conn:
+            cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='file_metadata'")
+            self.assertIsNotNone(cursor.fetchone())
+
+            cursor = conn.execute("SELECT file_name FROM file_metadata WHERE file_name='test.txt'")
+            row = cursor.fetchone()
+            self.assertIsNotNone(row)
+            self.assertEqual(row[0], 'test.txt')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `MetadataGenerator.save_file_metadata` method was vulnerable to a severe SQL injection attack. It constructed an `INSERT OR REPLACE` query dynamically by joining dictionary keys (`', '.join(columns)`). If an attacker passed a maliciously crafted dictionary key (e.g., `{"malicious_col) VALUES (1); DROP TABLE file_metadata; --": "value"}`), it would execute arbitrary SQL commands.
🎯 **Impact:** An attacker could execute arbitrary SQL, potentially dropping tables, corrupting data, or executing unauthorized database operations.
🔧 **Fix:** Refactored `save_file_metadata` to proactively fetch the valid database schema columns using `PRAGMA table_info(file_metadata)`. It now strictly filters the incoming metadata dictionary to only allow keys that perfectly match the established database schema before dynamically building the SQL query.
✅ **Verification:** A test suite `tests/test_metadata_generator_sql_injection.py` was created to verify the exploit no longer works.

---
*PR created automatically by Jules for task [560968154507455890](https://jules.google.com/task/560968154507455890) started by @thebearwithabite*