### PR TITLE
⚡ Bolt: Combine multiple SQLite aggregation queries in `get_statistics`

### DIFF
--- a/local_metadata_store.py
+++ b/local_metadata_store.py
@@ -902,21 +902,23 @@ class LocalMetadataStore:
             with self._get_cursor() as cursor:
                 stats = {}
                 
-                # File counts
-                cursor.execute("SELECT COUNT(*) FROM files")
-                stats['total_files'] = cursor.fetchone()[0]
+                # File and storage stats
+                # Optimized: Consolidated four sequential COUNT and SUM queries into a single query
+                # using conditional aggregation to prevent multiple full table/index scans.
+                cursor.execute("""
+                    SELECT
+                        COUNT(*),
+                        COALESCE(SUM(CASE WHEN is_cached = TRUE THEN 1 ELSE 0 END), 0),
+                        COALESCE(SUM(size_bytes), 0),
+                        COALESCE(SUM(CASE WHEN is_cached = TRUE THEN size_bytes ELSE 0 END), 0)
+                    FROM files
+                """)
+                total_files, cached_files, total_size_bytes, cached_size_bytes = cursor.fetchone()
                 
-                cursor.execute("SELECT COUNT(*) FROM files WHERE is_cached = TRUE")
-                stats['cached_files'] = cursor.fetchone()[0]
-                
-                # Storage stats
-                cursor.execute("SELECT SUM(size_bytes) FROM files")
-                result = cursor.fetchone()[0]
-                stats['total_size_bytes'] = result or 0
-                
-                cursor.execute("SELECT SUM(size_bytes) FROM files WHERE is_cached = TRUE")
-                result = cursor.fetchone()[0]
-                stats['cached_size_bytes'] = result or 0
+                stats['total_files'] = total_files
+                stats['cached_files'] = cached_files
+                stats['total_size_bytes'] = total_size_bytes
+                stats['cached_size_bytes'] = cached_size_bytes
                 
                 # Classification stats
                 cursor.execute("SELECT category, COUNT(*) FROM classifications GROUP BY category")


### PR DESCRIPTION
* 💡 What: Combine sequential `COUNT` and `SUM` queries on the `files` table in `get_statistics` into a single query using conditional aggregation. Added an explanatory comment.
* 🎯 Why: This avoids N+1 full table/index scans, saving 3 full table scans per call and significantly improving database read performance.
* 📊 Impact: Requires only 1 table scan instead of 4, reducing query times for large tables.
* 🔬 Measurement: Observe database query execution time and `get_statistics` latency before and after optimization on a large metadata database.

---
*PR created automatically by Jules for task [1944902660693838017](https://jules.google.com/task/1944902660693838017) started by @thebearwithabite*