### PR TITLE
🎨 Palette: Improve Accessibility for Classification Preview Skip Button

### DIFF
--- a/frontend_v2/src/components/organize/ClassificationPreview.tsx
+++ b/frontend_v2/src/components/organize/ClassificationPreview.tsx
@@ -192,9 +192,11 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         </button>
         <button
           onClick={handleSkip}
-          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white"
+          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          aria-label="Skip"
+          title="Skip"
         >
-          <X size={20} />
+          <X size={20} aria-hidden="true" />
         </button>
       </div>
 


### PR DESCRIPTION
💡 What: Added aria attributes and focus-visible styling to the skip button in `ClassificationPreview.tsx`.
🎯 Why: The previous button was an icon-only element without an accessible name, a tooltip for mouse users, or a clear focus ring for keyboard users.
📸 Before/After: Visual focus ring now properly displayed.
♿ Accessibility: Better screen reader parsing with explicit `aria-label` and `aria-hidden` tags, along with visible keyboard focus styling.

---
*PR created automatically by Jules for task [17852007085197598688](https://jules.google.com/task/17852007085197598688) started by @thebearwithabite*