### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection in vision content extractor

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,9 @@
 2. Verify path containment within allowed boundaries using `is_relative_to` (or `security_utils.validate_path_within_base`).
 3. For endpoints invoking system commands with user-provided paths, ensure paths are absolute to prevent them from being parsed as options (flags starting with `-`), or explicitly block paths where `.name.startswith('-')`.
 4. Special care must be given to URL support to prevent bypasses like `file:///etc/passwd` when filtering `http`/`https`.
+
+## 2024-05-31 - Argument Injection via `subprocess.run` (ffprobe/ffmpeg)
+
+**Vulnerability:** The `vision_content_extractor.py` module passed dynamically generated strings (`str(file_path)`) to `subprocess.run` calls executing external binaries like `ffprobe` and `ffmpeg`. If a user-supplied filename started with a dash (`-`), it could be interpreted as an unintended command-line argument, allowing argument injection.
+**Learning:** Even when path traversal is mitigated, passing raw string paths to system commands remains dangerous if the paths can be mistaken for options/flags by the receiving executable.
+**Prevention:** To prevent argument injection in system commands like `subprocess.run`, convert relative `Path` objects to absolute strings using `str(path.absolute())`. This guarantees the argument starts with a directory separator (e.g., `/` or `C:\`) instead of a dash.

--- a/vision_content_extractor.py
+++ b/vision_content_extractor.py
@@ -312,7 +312,7 @@ Focus on details that would help with project categorization and file organizati
             # Get video duration
             import subprocess
             cmd = ['ffprobe', '-v', 'quiet', '-show_entries', 'format=duration', 
-                   '-of', 'csv=p=0', str(file_path)]
+                   '-of', 'csv=p=0', str(file_path.absolute())]
             result = subprocess.run(cmd, capture_output=True, text=True)
             
             if result.returncode != 0:
@@ -353,11 +353,11 @@ Focus on details that would help with project categorization and file organizati
             )
             
             cmd = [
-                'ffmpeg', '-i', str(file_path), 
+                'ffmpeg', '-i', str(file_path.absolute()),
                 '-filter_complex', filter_complex,
                 '-map', '[outv]', '-map', '[outa]',
                 '-y',  # Overwrite output
-                str(sample_path)
+                str(sample_path.absolute())
             ]
             
             # Run ffmpeg


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix argument injection in vision content extractor

Vulnerability: `vision_content_extractor.py` passed dynamically generated strings (`str(file_path)`) to `subprocess.run` calls executing external binaries like `ffprobe` and `ffmpeg`. If a user-supplied filename started with a dash (`-`), it could be interpreted as an unintended command-line argument by these programs.
Fix: Converted relative `Path` objects to absolute strings using `str(path.absolute())` before passing them to the system commands. This guarantees the argument starts with a directory separator (e.g., `/` or `C:\`) instead of a dash, neutralizing argument injection vectors. Also added a journal entry to `.jules/sentinel.md` documenting the vulnerability and fix.

---
*PR created automatically by Jules for task [6010542171612729756](https://jules.google.com/task/6010542171612729756) started by @thebearwithabite*