### PR TITLE
🎨 Palette: Make RecentActivityFeed Undo button accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-16 - Make hover-only actions keyboard accessible
+**Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
+**Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.

--- a/frontend_v2/src/components/dashboard/RecentActivityFeed.tsx
+++ b/frontend_v2/src/components/dashboard/RecentActivityFeed.tsx
@@ -88,10 +88,11 @@ export default function RecentActivityFeed() {
 
             <button
               onClick={() => handleUndo(op.operation_id)}
-              className="p-2 rounded-lg hover:bg-white/10 transition-colors opacity-0 group-hover:opacity-100"
-              title="Undo this operation"
+              className="p-2 rounded-lg hover:bg-white/10 transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-warning focus-visible:outline-none"
+              title={`Undo ${op.operation_type} of ${op.original_filename}`}
+              aria-label={`Undo ${op.operation_type} of ${op.original_filename}`}
             >
-              <RotateCcw size={16} className="text-warning hover:text-warning/80" />
+              <RotateCcw size={16} className="text-warning hover:text-warning/80" aria-hidden="true" />
             </button>
           </div>
         ))}


### PR DESCRIPTION
🎨 **Palette UX Polish**

**What:** Made the "Undo" button in the Dashboard's Recent Activity Feed fully accessible to keyboard and screen reader users.

**Why:** The button was previously completely invisible to keyboard-only users who navigate via the \`Tab\` key, as it only appeared on hover (\`group-hover:opacity-100\`). This violates WCAG accessibility guidelines and prevents users with mobility impairments from quickly undoing recent actions.

**Accessibility Improvements:**
- **Keyboard Access:** The button now elegantly appears when focused and features a clearly visible warning-colored focus ring.
- **Screen Reader Context:** Instead of reading a generic "Undo this operation", screen readers will now read the specific action (e.g., "Undo move of important_doc.pdf") thanks to a dynamic \`aria-label\`.
- **Icon Hiding:** The decorative \`RotateCcw\` icon is now explicitly hidden from screen readers to prevent redundant or confusing readout.

---
*PR created automatically by Jules for task [3597087024221962902](https://jules.google.com/task/3597087024221962902) started by @thebearwithabite*