### PR TITLE
🎨 Palette: Make hover-only Undo button keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-17 - [Accessible hover-only elements]
+**Learning:** Elements hidden via `opacity-0 group-hover:opacity-100` are inaccessible to keyboard navigation because they remain invisible on focus.
+**Action:** Always add `focus-visible:opacity-100` along with explicit outline rings (`focus-visible:outline-none focus-visible:ring-2`) to ensure valid keyboard accessibility for hidden elements.

--- a/frontend_v2/src/components/dashboard/RecentActivityFeed.tsx
+++ b/frontend_v2/src/components/dashboard/RecentActivityFeed.tsx
@@ -88,10 +88,11 @@ export default function RecentActivityFeed() {
 
             <button
               onClick={() => handleUndo(op.operation_id)}
-              className="p-2 rounded-lg hover:bg-white/10 transition-colors opacity-0 group-hover:opacity-100"
+              className="p-2 rounded-lg hover:bg-white/10 transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
               title="Undo this operation"
+              aria-label="Undo this operation"
             >
-              <RotateCcw size={16} className="text-warning hover:text-warning/80" />
+              <RotateCcw size={16} className="text-warning hover:text-warning/80" aria-hidden="true" />
             </button>
           </div>
         ))}


### PR DESCRIPTION
**💡 What:** 
Added focus-visible classes (`focus-visible:opacity-100`, `focus-visible:ring-2`, etc.) to the Undo button in the `RecentActivityFeed` component. Added an `aria-label` to the button and `aria-hidden="true"` to the inner icon.

**🎯 Why:** 
The Undo button was using `opacity-0` and `group-hover:opacity-100` to show/hide. This pattern completely breaks keyboard accessibility because users tabbing through the interface couldn't see the button when it received focus. Adding the focus-visible overrides ensures the button appears and has a clear focus ring when accessed via keyboard. The ARIA attributes improve the experience for screen reader users by explicitly announcing the button's purpose and hiding the redundant visual icon.

**♿ Accessibility:** 
- Made an invisible interactive element visible on keyboard focus.
- Added explicit focus ring.
- Added `aria-label` for screen readers.
- Hid decorative icon from screen readers using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [9758071263537463979](https://jules.google.com/task/9758071263537463979) started by @thebearwithabite*