### PR TITLE
🎨 Palette: [Accessibility] Add ARIA labels to icon-only buttons in Settings components

### DIFF
--- a/frontend_v2/src/components/settings/IdentityManager.tsx
+++ b/frontend_v2/src/components/settings/IdentityManager.tsx
@@ -188,14 +188,16 @@ export default function IdentityManager() {
                                     <button
                                         onClick={() => handleOpenDialog(identity)}
                                         className="p-1.5 text-white/40 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+                                        aria-label={`Edit identity ${identity.name}`}
                                     >
-                                        <Edit2 size={14} />
+                                        <Edit2 size={14} aria-hidden="true" />
                                     </button>
                                     <button
                                         onClick={() => handleDelete(identity.id)}
                                         className="p-1.5 text-white/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors"
+                                        aria-label={`Delete identity ${identity.name}`}
                                     >
-                                        <Trash2 size={14} />
+                                        <Trash2 size={14} aria-hidden="true" />
                                     </button>
                                 </div>
                             </div>
@@ -240,8 +242,9 @@ export default function IdentityManager() {
                             <button
                                 onClick={() => setIsDialogOpen(false)}
                                 className="p-2 text-white/40 hover:text-white transition-colors"
+                                aria-label="Close dialog"
                             >
-                                <X size={20} />
+                                <X size={20} aria-hidden="true" />
                             </button>
                         </div>
 

--- a/frontend_v2/src/components/settings/TaxonomySettings.tsx
+++ b/frontend_v2/src/components/settings/TaxonomySettings.tsx
@@ -221,16 +221,18 @@ export const TaxonomySettings: React.FC = () => {
                                                 disabled={cat.locked}
                                                 className="p-2 hover:bg-white/10 rounded-lg text-white/60 hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                                                 title="Edit Metadata"
+                                                aria-label={`Edit metadata for ${cat.display_name}`}
                                             >
-                                                <Edit size={18} />
+                                                <Edit size={18} aria-hidden="true" />
                                             </button>
                                             <button
                                                 onClick={() => handleRenameOpen(cat)}
                                                 disabled={cat.locked}
                                                 className="p-2 hover:bg-white/10 rounded-lg text-white/60 hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                                                 title="Rename Category & Folder"
+                                                aria-label={`Rename category and folder for ${cat.display_name}`}
                                             >
-                                                <FolderEdit size={18} />
+                                                <FolderEdit size={18} aria-hidden="true" />
                                             </button>
                                         </div>
                                     </td>
@@ -247,8 +249,8 @@ export const TaxonomySettings: React.FC = () => {
                     <div className="bg-[#1a1a1a] border border-white/20 rounded-2xl w-full max-w-md shadow-2xl animate-in fade-in zoom-in duration-200">
                         <div className="flex justify-between items-center p-6 border-b border-white/10">
                             <h3 className="text-lg font-bold text-white">Edit Metadata: {editCategory.display_name}</h3>
-                            <button onClick={() => setEditCategory(null)} className="text-white/40 hover:text-white">
-                                <X size={20} />
+                            <button onClick={() => setEditCategory(null)} className="text-white/40 hover:text-white" aria-label="Close edit dialog">
+                                <X size={20} aria-hidden="true" />
                             </button>
                         </div>
                         <div className="p-6 space-y-4">
@@ -290,8 +292,8 @@ export const TaxonomySettings: React.FC = () => {
                     <div className="bg-[#1a1a1a] border border-white/20 rounded-2xl w-full max-w-md shadow-2xl animate-in fade-in zoom-in duration-200">
                         <div className="flex justify-between items-center p-6 border-b border-white/10">
                             <h3 className="text-lg font-bold text-white">Rename Category</h3>
-                            <button onClick={() => setRenameCategory(null)} className="text-white/40 hover:text-white">
-                                <X size={20} />
+                            <button onClick={() => setRenameCategory(null)} className="text-white/40 hover:text-white" aria-label="Close rename dialog">
+                                <X size={20} aria-hidden="true" />
                             </button>
                         </div>
                         <div className="p-6 space-y-4">
@@ -338,8 +340,8 @@ export const TaxonomySettings: React.FC = () => {
                     <div className="bg-[#1a1a1a] border border-white/20 rounded-2xl w-full max-w-lg shadow-2xl animate-in fade-in zoom-in duration-200 max-h-[90vh] overflow-y-auto">
                         <div className="flex justify-between items-center p-6 border-b border-white/10 sticky top-0 bg-[#1a1a1a] z-10">
                             <h3 className="text-lg font-bold text-white">Add New Category</h3>
-                            <button onClick={() => setCreateDialogOpen(false)} className="text-white/40 hover:text-white">
-                                <X size={20} />
+                            <button onClick={() => setCreateDialogOpen(false)} className="text-white/40 hover:text-white" aria-label="Close create dialog">
+                                <X size={20} aria-hidden="true" />
                             </button>
                         </div>
                         <div className="p-6 space-y-4">


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to icon-only buttons

**💡 What:** Added `aria-label` attributes to icon-only `<button>` elements and `aria-hidden="true"` to their inner SVG icons in `TaxonomySettings.tsx` and `IdentityManager.tsx`.

**🎯 Why:** Without an `aria-label`, screen readers have no text content to announce for these buttons, making it impossible for visually impaired users to know what actions they perform (e.g., closing a modal, editing an item, or deleting an item). By explicitly hiding the SVG icons and labeling the buttons, the interface becomes fully accessible via keyboard and screen reader.

**♿ Accessibility:**
- Added `aria-label` to buttons: "Edit metadata...", "Rename category...", "Close edit dialog", "Close rename dialog", "Close create dialog", "Edit identity...", "Delete identity...", "Close dialog".
- Added `aria-hidden="true"` to all inner `lucide-react` icons within those buttons.

---
*PR created automatically by Jules for task [5298124055054002474](https://jules.google.com/task/5298124055054002474) started by @thebearwithabite*