### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in metadata database migration and metadata save

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,13 @@
 **Prevention:**
 1. Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
 2. Absolute paths always begin with a directory separator (`/` on Unix) or a drive letter (`C:\` on Windows), guaranteeing the command-line tool parses them as file paths rather than flags or options.
+## 2024-05-30 - SQL Injection via Unvalidated Dictionary Keys in Dynamic Queries
+
+**Vulnerability:** The `MetadataGenerator.save_file_metadata` method was vulnerable to SQL injection because it dynamically constructed an `INSERT OR REPLACE INTO file_metadata` query by directly using the dictionary keys and values provided by the caller without validating the keys against the actual database schema. Additionally, `_migrate_database_schema` directly interpolated column names into `ALTER TABLE` statements without verifying they were valid identifiers.
+
+**Learning:** When constructing dynamic SQL queries (e.g., `INSERT` or `UPDATE` with dynamically generated column names), standard `?` parameterization does not protect column keys. You must use an explicit schema allowlist (e.g., fetching `PRAGMA table_info` from the database) to filter dictionary keys and prevent SQL injection. For DDL statements like `ALTER TABLE`, user input must be strictly validated as a valid SQL identifier (e.g., using `.isidentifier()`).
+
+**Prevention:**
+1. Dynamically fetch the allowed schema using `PRAGMA table_info(table_name)`.
+2. Filter the incoming dictionary keys against the allowed schema to ensure only safe, existing columns are included in the query.
+3. For dynamic column names in DDL statements, validate them using `col_name.isidentifier()` to ensure they contain only valid characters.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -229,7 +229,10 @@ class MetadataGenerator:
             
             # Step 5: Add missing columns atomically
             migration_count = 0
+            # Define allowed characters for column names to prevent SQL injection
             for col_name, col_type in gdrive_columns.items():
+                if not col_name.isidentifier():
+                    continue
                 if col_name not in existing_columns:
                     conn.execute(f"ALTER TABLE file_metadata ADD COLUMN {col_name} {col_type}")
                     migration_count += 1
@@ -467,9 +470,20 @@ class MetadataGenerator:
         
         try:
             with sqlite3.connect(self.db_path) as conn:
+                # Fetch valid columns to prevent SQL injection
+                cursor = conn.execute("PRAGMA table_info(file_metadata)")
+                valid_columns = {row[1] for row in cursor.fetchall()}
+
+                # Filter metadata to only include valid columns
+                filtered_metadata = {k: v for k, v in metadata.items() if k in valid_columns}
+
+                if not filtered_metadata:
+                    print("⚠️  No valid metadata fields to save.")
+                    return False
+
                 # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                columns = list(filtered_metadata.keys())
+                values = list(filtered_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SQL injection in metadata database migration and metadata save

🚨 Severity: CRITICAL
💡 Vulnerability: SQL injection was possible in `metadata_generator.py` through `save_file_metadata` and `_migrate_database_schema`. The dynamic query constructed via `INSERT OR REPLACE INTO` accepted unsanitized dictionary keys, and `ALTER TABLE` operations accepted unsanitized column names.
🎯 Impact: An attacker could execute arbitrary SQL commands by passing malicious dictionary keys or table column names, potentially taking complete control over the application's SQLite database or wiping data.
🔧 Fix:
- For `save_file_metadata`: Implemented a strict schema allowlist by directly querying `PRAGMA table_info(file_metadata)`. Keys are filtered against this allowlist before insertion.
- For `_migrate_database_schema`: Applied `.isidentifier()` to validate that column names are valid alphanumeric strings before being inserted into `ALTER TABLE` commands.
✅ Verification: Ran `test_metadata.py` and `test_database_diagnostics.py` to confirm the functionality acts correctly while maintaining robustness against SQL injection.

---
*PR created automatically by Jules for task [10452449783819753531](https://jules.google.com/task/10452449783819753531) started by @thebearwithabite*