### PR TITLE
🎨 Palette: Add ARIA labels to script upload buttons in VeoProjectForm

### DIFF
--- a/frontend_v2/src/components/veo/VeoProjectForm.tsx
+++ b/frontend_v2/src/components/veo/VeoProjectForm.tsx
@@ -103,8 +103,8 @@ const VeoProjectForm: React.FC<VeoProjectFormProps> = ({
                     <div className="flex justify-between items-center mb-8 relative z-10">
                         <p className="text-[11px] text-white/40 font-bold uppercase tracking-widest leading-none">Draft your scene beats or upload a screenplay</p>
                         <div className="flex gap-2">
-                            <button type="button" onClick={() => scriptFileInputRef.current?.click()} className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileUploadIcon className="w-4 h-4" /></button>
-                            <button type="button" className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileAudioIcon className="w-4 h-4" /></button>
+                            <button aria-label="Upload text script" type="button" onClick={() => scriptFileInputRef.current?.click()} className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileUploadIcon aria-hidden="true" className="w-4 h-4" /></button>
+                            <button aria-label="Upload audio script" type="button" className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileAudioIcon aria-hidden="true" className="w-4 h-4" /></button>
                         </div>
                     </div>
 


### PR DESCRIPTION
🎨 **Palette: Add ARIA labels to icon-only buttons**

💡 **What:** Added `aria-label`s to the text ("Upload text script") and audio ("Upload audio script") upload buttons in `VeoProjectForm.tsx`. Also added `aria-hidden="true"` to the SVG icons themselves.
🎯 **Why:** Icon-only buttons without `aria-label`s are completely invisible/incomprehensible to users relying on screen readers. This ensures they know exactly what these two buttons do.
📸 **Before/After:** The visual design is identical, but the semantic HTML now properly supports assistive technologies.
♿ **Accessibility:** This directly fixes a WCAG Level A violation (Missing alternative text for active images/icons) making the "Script Manifest" upload flow accessible.

---
*PR created automatically by Jules for task [669374909039021040](https://jules.google.com/task/669374909039021040) started by @thebearwithabite*