### PR TITLE
🎨 Palette: Add keyboard focus visibility to hover-only actions

### DIFF
--- a/frontend_v2/src/components/veo/AssetLibrary.tsx
+++ b/frontend_v2/src/components/veo/AssetLibrary.tsx
@@ -237,8 +237,9 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
             <button
                 onClick={onRemove}
                 type="button"
-                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100">
-                <XMarkIcon className="w-3 h-3" />
+                aria-label={`Remove asset ${asset.name}`}
+                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100 focus-visible:scale-100 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none">
+                <XMarkIcon className="w-3 h-3" aria-hidden="true" />
             </button>
 
             <div className="aspect-[4/3] bg-black/40 relative overflow-hidden">
@@ -261,11 +262,12 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
                     </label>
                 )}
                 {asset.image && (
-                    <label className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-md p-2 rounded-full cursor-pointer hover:bg-indigo-600 border border-white/10 opacity-0 group-hover:opacity-100 transition-all scale-75 group-hover:scale-100">
-                        <UploadCloudIcon className="w-3 h-3 text-white" />
+                    <label className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-md p-2 rounded-full cursor-pointer hover:bg-indigo-600 border border-white/10 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-all scale-75 group-hover:scale-100 focus-within:scale-100 focus-within:ring-2 focus-within:ring-indigo-500 focus-within:outline-none">
+                        <UploadCloudIcon className="w-3 h-3 text-white" aria-hidden="true" />
                         <input
                             type="file"
-                            className="hidden"
+                            aria-label={`Update image for ${asset.name}`}
+                            className="sr-only"
                             onChange={onUpload}
                             accept="image/png, image/jpeg, image/webp"
                         />

--- a/frontend_v2/src/components/veo/ShotCard.tsx
+++ b/frontend_v2/src/components/veo/ShotCard.tsx
@@ -95,14 +95,14 @@ const ShotCard: React.FC<ShotCardProps> = ({
                         <pre className="text-indigo-400/80 leading-relaxed">
                             <code>{shot.veoJson ? JSON.stringify(shot.veoJson, null, 2) : '// Awaiting Director Breakdown...'}</code>
                         </pre>
-                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-all translate-y-2 group-hover:translate-y-0">
+                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-all translate-y-2 group-hover:translate-y-0 focus-within:translate-y-0">
                             <button
                                 onClick={() => {
                                     navigator.clipboard.writeText(JSON.stringify(shot.veoJson, null, 2));
                                     setCopyButtonText('Copied!');
                                     setTimeout(() => setCopyButtonText('Copy JSON'), 2000);
                                 }}
-                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all"
+                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none"
                             >
                                 {copyButtonText}
                             </button>


### PR DESCRIPTION
💡 What: Added `focus-visible` and `focus-within` states to actions previously hidden behind `opacity-0 group-hover:opacity-100` and added missing `aria-label`s to icon-only buttons. Fixed input accessibility by using `sr-only` instead of `hidden`.
🎯 Why: Elements hidden via opacity are completely inaccessible to keyboard-only users navigating via Tab if they don't have focus states. Icon-only buttons without ARIA labels are meaningless to screen reader users. `display: none` inputs cannot receive focus.
📸 Before/After: Visual changes confirmed via Playwright verification (screenshots taken).
♿ Accessibility: Improves keyboard navigation visibility (WCAG 2.4.7 Focus Visible) and screen reader support for icon-only buttons (WCAG 4.1.2 Name, Role, Value).

---
*PR created automatically by Jules for task [18365142763396075398](https://jules.google.com/task/18365142763396075398) started by @thebearwithabite*