### PR TITLE
⚡ Bolt: Optimize interactive batch processing database inserts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2025-05-27 - [Bulk SQLite Inserts and Connection Reuse for Tagging]
 **Learning:** Sequential `.execute` calls for `INSERT OR REPLACE` inside nested loops over large arrays (like tags) coupled with opening independent DB connections per method creates a severe N+1 problem. Benchmarks showed replacing it with a single shared connection and `executemany` arrays resulted in an ~2x speedup on typical batch tagging workloads.
 **Action:** Always batch related SQL records using `.executemany()` and pass an optional `db_connection` downstream to nested operations instead of establishing a new database connection every time.
+
+## 2025-09-09 - [Bulk SQLite Inserts for Interactive User Feedback]
+**Learning:** Calling `conn.execute` in a loop to `INSERT INTO user_feedback` for each file inside `InteractiveBatchProcessor._record_user_decision` causes significant N+1 overhead during large batch processing operations. Preparing the row tuples beforehand and calling `conn.executemany` once substantially accelerates database persistence.
+**Action:** Always prepare lists of tuples and use `.executemany()` instead of `.execute()` within loops for repetitive database inserts.

--- a/interactive_batch_processor.py
+++ b/interactive_batch_processor.py
@@ -1357,22 +1357,32 @@ class InteractiveBatchProcessor:
     def _record_user_decision(self, session_id: str, group: BatchGroup, user_decision: Dict[str, Any], result: Dict[str, Any]):
         """Record user decision for learning"""
         try:
-            with sqlite3.connect(self.batch_db_path) as conn:
-                for fp in group.file_previews:
-                    conn.execute("""
+            # OPTIMIZATION: Use executemany for bulk insert to prevent N+1 overhead and speed up processing
+            timestamp = datetime.now().isoformat()
+            decision_json = json.dumps(user_decision)
+            action = user_decision.get("action", "unknown")
+
+            feedback_data = []
+            for fp in group.file_previews:
+                feedback_id = hashlib.md5(f"{session_id}_{fp.file_path}_{timestamp}".encode()).hexdigest()[:12]
+                feedback_data.append((
+                    feedback_id,
+                    session_id,
+                    fp.file_path,
+                    fp.predicted_category,
+                    action,
+                    timestamp,
+                    decision_json
+                ))
+
+            if feedback_data:
+                with sqlite3.connect(self.batch_db_path) as conn:
+                    conn.executemany("""
                         INSERT INTO user_feedback
                         (feedback_id, session_id, file_path, predicted_action, user_action, feedback_time, comments)
                         VALUES (?, ?, ?, ?, ?, ?, ?)
-                    """, (
-                        hashlib.md5(f"{session_id}_{fp.file_path}_{datetime.now().isoformat()}".encode()).hexdigest()[:12],
-                        session_id,
-                        fp.file_path,
-                        fp.predicted_category,
-                        user_decision.get("action", "unknown"),
-                        datetime.now().isoformat(),
-                        json.dumps(user_decision)
-                    ))
-                conn.commit()
+                    """, feedback_data)
+                    conn.commit()
         except Exception as e:
             self.logger.error(f"Error recording user decision: {e}")
 


### PR DESCRIPTION
💡 What: Replaced an N+1 SQLite `execute()` loop with a single `executemany()` operation inside `InteractiveBatchProcessor._record_user_decision` for storing batch user feedback.
🎯 Why: Iterating over potentially large batches of `file_previews` and inserting records one by one created a significant N+1 I/O overhead. This optimizes database ingestion.
📊 Impact: Expected to reduce time spent persisting feedback by ~2-5x during large batch processing interactions since the database interaction happens in bulk instead of repeating per record.
🔬 Measurement: Verify by executing the batch processor CLI and profiling the `_record_user_decision` call. The local compilation checks out cleanly.

---
*PR created automatically by Jules for task [7013906706428906551](https://jules.google.com/task/7013906706428906551) started by @thebearwithabite*