### PR TITLE
🎨 Palette: Add ARIA label to skip button

### DIFF
--- a/frontend_v2/src/components/organize/ClassificationPreview.tsx
+++ b/frontend_v2/src/components/organize/ClassificationPreview.tsx
@@ -193,8 +193,9 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         <button
           onClick={handleSkip}
           className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white"
+          aria-label="Skip and organize later"
         >
-          <X size={20} />
+          <X size={20} aria-hidden="true" />
         </button>
       </div>
 


### PR DESCRIPTION
💡 **What:** Added `aria-label` to the icon-only "Skip" button in `ClassificationPreview.tsx` and hid the decorative `X` icon from screen readers using `aria-hidden`.

🎯 **Why:** To ensure screen readers announce the button's purpose clearly rather than reading out confusing SVG code or ignoring it, making the AI file analyst interface more accessible.

📸 **Before/After:** No visual changes.

♿ **Accessibility:**
- Added `aria-label="Skip and organize later"` to the button.
- Added `aria-hidden="true"` to the `X` icon.

---
*PR created automatically by Jules for task [3793021424424063316](https://jules.google.com/task/3793021424424063316) started by @thebearwithabite*