### PR TITLE
🎨 Palette: Add focus states to ConnectionStatus retry button

### DIFF
--- a/frontend_v2/src/components/layout/ConnectionStatus.tsx
+++ b/frontend_v2/src/components/layout/ConnectionStatus.tsx
@@ -40,7 +40,7 @@ export default function ConnectionStatus() {
             <button
                 onClick={checkConnection}
                 disabled={isChecking}
-                className="text-xs bg-background/20 hover:bg-background/30 px-2 py-1 rounded flex items-center gap-1 transition-colors"
+                className="text-xs bg-background/20 hover:bg-background/30 px-2 py-1 rounded flex items-center gap-1 transition-colors focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"
             >
                 <RefreshCw className={`h-3 w-3 ${isChecking ? 'animate-spin' : ''}`} />
                 Retry Now


### PR DESCRIPTION
💡 **What:** Added proper focus ring styling to the "Retry Now" button in `ConnectionStatus.tsx`.
🎯 **Why:** To improve keyboard accessibility. Previously, the button lacked an explicit focus indicator, making it difficult for keyboard users to know when it was focused during a backend disconnect event.
📸 **Before/After:** (Visual verified locally - focus ring now appears on tab).
♿ **Accessibility:** Added standard `focus-visible` Tailwind classes to provide a clear focus indicator only when navigating via keyboard.

---
*PR created automatically by Jules for task [8129928920205548176](https://jules.google.com/task/8129928920205548176) started by @thebearwithabite*