### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons in VeoProjectForm

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-16 - Make hover-only actions keyboard accessible
 **Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
 **Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.
+
+## 2024-03-25 - ARIA labels for icon-only buttons
+**Learning:** Icon-only buttons with decorative visual elements (like Lucide React SVG icons) need an explicit `aria-label` for screen readers, and the inner icon must have `aria-hidden="true"` to prevent duplicate or confusing announcements. Focus states using `focus-visible` enhance keyboard accessibility.
+**Action:** Always pair `aria-label` and `title` on icon-only `<button>` tags and add `aria-hidden="true"` to the child icon element.

--- a/frontend_v2/src/components/veo/VeoProjectForm.tsx
+++ b/frontend_v2/src/components/veo/VeoProjectForm.tsx
@@ -103,8 +103,8 @@ const VeoProjectForm: React.FC<VeoProjectFormProps> = ({
                     <div className="flex justify-between items-center mb-8 relative z-10">
                         <p className="text-[11px] text-white/40 font-bold uppercase tracking-widest leading-none">Draft your scene beats or upload a screenplay</p>
                         <div className="flex gap-2">
-                            <button type="button" onClick={() => scriptFileInputRef.current?.click()} className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileUploadIcon className="w-4 h-4" /></button>
-                            <button type="button" className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileAudioIcon className="w-4 h-4" /></button>
+                            <button type="button" aria-label="Upload screenplay" title="Upload screenplay" onClick={() => scriptFileInputRef.current?.click()} className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all focus-visible:ring-2 focus-visible:ring-indigo-500/50 outline-none"><FileUploadIcon className="w-4 h-4" aria-hidden="true" /></button>
+                            <button type="button" aria-label="Upload audio" title="Upload audio" className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all focus-visible:ring-2 focus-visible:ring-indigo-500/50 outline-none"><FileAudioIcon className="w-4 h-4" aria-hidden="true" /></button>
                         </div>
                     </div>
 


### PR DESCRIPTION
💡 **What:** Added `aria-label`, `title`, and `focus-visible` styles to the script and audio upload icon-only buttons. Added `aria-hidden="true"` to the inner SVG icons.
🎯 **Why:** Icon-only buttons are completely inaccessible to screen readers without ARIA labels, and without a `title` attribute, sighted users have no tooltip to explain their function. Furthermore, inner SVGs can sometimes be announced redundantly by screen readers if not explicitly hidden. The focus styles ensure the buttons are visible when navigating via keyboard.
♿ **Accessibility:**
- Added `aria-label` for screen reader announcement.
- Added `aria-hidden="true"` to decorative child SVGs.
- Added `focus-visible:ring-2` to support keyboard tab navigation.

---
*PR created automatically by Jules for task [11444139389410851734](https://jules.google.com/task/11444139389410851734) started by @thebearwithabite*