### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix argument injection in system scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,12 @@
 **Prevention:**
 1. Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
 2. Absolute paths always begin with a directory separator (`/` on Unix) or a drive letter (`C:\` on Windows), guaranteeing the command-line tool parses them as file paths rather than flags or options.
+
+## 2024-05-30 - System Script Argument Injection Vulnerability
+
+**Vulnerability:** Several system scripts (`system_storage_cleanup.py`, `gdrive_staging.py`, `dev-archive/repair_mislabeled_jsons.py`) were passing unvalidated `pathlib.Path` objects directly to `subprocess.run` calls without resolving them to absolute strings. For commands like `rm`, `du`, and `file`, this left the system vulnerable to argument injection if a directory or file name started with a hyphen (e.g., `-rf`).
+
+**Learning:** Argument injection vulnerabilities are not limited to core application code; maintenance, cleanup, and utility scripts that interact with the file system via external binaries are equally susceptible. Using `str(path)` is unsafe for system calls because relative path components or filenames starting with a hyphen can be misinterpreted as command-line flags by the executing tool.
+
+**Prevention:**
+1. System utility scripts invoking external binaries must enforce `.absolute()` on all `pathlib.Path` objects before string conversion (e.g., `str(path.absolute())`) to guarantee paths begin with a root slash (`/`) or drive letter, neutralizing argument injection vectors.

--- a/dev-archive/repair_mislabeled_jsons.py
+++ b/dev-archive/repair_mislabeled_jsons.py
@@ -34,7 +34,7 @@ def get_actual_mime(file_path):
     import time
     for attempt in range(2):
         try:
-            result = subprocess.run(['file', '--mime-type', '-b', str(file_path)], 
+            result = subprocess.run(['file', '--mime-type', '-b', str(file_path.absolute())],
                                    capture_output=True, text=True, check=True)
             return result.stdout.strip()
         except:

--- a/gdrive_staging.py
+++ b/gdrive_staging.py
@@ -22,7 +22,7 @@ def stage_directory_to_gdrive(source_dir: Path, staging_name: str = None) -> boo
         return False
     
     # Get directory size
-    result = subprocess.run(['du', '-sh', str(source_dir)], capture_output=True, text=True)
+    result = subprocess.run(['du', '-sh', str(source_dir.absolute())], capture_output=True, text=True)
     dir_size = result.stdout.split()[0] if result.stdout else "unknown"
     
     print(f"📦 Staging Directory to Google Drive")

--- a/system_storage_cleanup.py
+++ b/system_storage_cleanup.py
@@ -77,7 +77,7 @@ class SystemStorageCleanup:
             if info['path'].exists():
                 try:
                     # Get actual size
-                    result = subprocess.run(['du', '-sh', str(info['path'])], 
+                    result = subprocess.run(['du', '-sh', str(info['path'].absolute())],
                                          capture_output=True, text=True)
                     if result.stdout:
                         size_str = result.stdout.split()[0]
@@ -188,12 +188,12 @@ class SystemStorageCleanup:
             else:
                 try:
                     # Get size before deletion for verification
-                    result = subprocess.run(['du', '-sh', str(docker_path)], 
+                    result = subprocess.run(['du', '-sh', str(docker_path.absolute())],
                                          capture_output=True, text=True)
                     size_before = result.stdout.split()[0] if result.stdout else "unknown"
                     
                     # Delete Docker data (safe since Docker isn't running)
-                    subprocess.run(['rm', '-rf', str(docker_path)], check=True)
+                    subprocess.run(['rm', '-rf', str(docker_path.absolute())], check=True)
                     print(f"   ✅ Deleted Docker data ({size_before})")
                     
                     # Recreate empty directory structure so Docker can start later
@@ -223,7 +223,7 @@ class SystemStorageCleanup:
                     total_freed += 1.0  # Estimated per path
                 else:
                     try:
-                        subprocess.run(['rm', '-rf', str(cache_path)], check=True)
+                        subprocess.run(['rm', '-rf', str(cache_path.absolute())], check=True)
                         print(f"   ✅ Cleaned: {cache_path}")
                         total_freed += 1.0
                     except Exception as e:
@@ -266,7 +266,7 @@ class SystemStorageCleanup:
                     for temp_dir in ['temp', 'AutoSave']:
                         temp_path = audacity_path / temp_dir
                         if temp_path.exists():
-                            subprocess.run(['rm', '-rf', str(temp_path)], check=True)
+                            subprocess.run(['rm', '-rf', str(temp_path.absolute())], check=True)
                     print(f"   ✅ Audacity temp files cleaned")
                     return 1.3
                 except Exception as e:


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Several system utilities (`system_storage_cleanup.py`, `gdrive_staging.py`, `dev-archive/repair_mislabeled_jsons.py`) were passing `pathlib.Path` objects to `subprocess.run` as raw strings. This created an argument injection vulnerability where path strings starting with a hyphen (e.g. `-rf`) would be evaluated as options by command-line tools like `rm`, `du`, and `file`, leading to arbitrary option execution.
🎯 **Impact**: Allowed privilege escalation or unauthorized system modifications (e.g. deleting unintended directories) if an attacker or unpredictable AI process generated a file name starting with `-`.
🔧 **Fix**: Enforced `.absolute()` on all `pathlib.Path` instances before casting to a string in `subprocess.run` calls. Since absolute paths always start with a root slash (`/`) or drive letter, the command-line arguments are guaranteed to be evaluated as file operands rather than options.
✅ **Verification**: Code statically verified, compiled locally, and a `sentinel.md` journal entry detailing the mitigation pattern has been added.

---
*PR created automatically by Jules for task [5405626011078644341](https://jules.google.com/task/5405626011078644341) started by @thebearwithabite*