### PR TITLE
🎨 Palette: Make hover-only actions keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-16 - Make hover-only actions keyboard accessible
 **Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
 **Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.
+
+## 2024-03-26 - Make hover-only file inputs keyboard accessible
+**Learning:** File inputs hidden with `className="hidden"` are completely inaccessible to screen readers and keyboard navigation, even when their `<label>` wrappers are visible. Hiding the label via `opacity-0 group-hover:opacity-100` compounds the issue for keyboard users.
+**Action:** When creating hover-revealed file uploads, use `focus-within:opacity-100` on the label container. Ensure the `<input type="file">` is kept in the DOM as focusable but visually hidden using `opacity-0 absolute inset-0 w-full h-full cursor-pointer`.

--- a/frontend_v2/src/components/veo/AssetLibrary.tsx
+++ b/frontend_v2/src/components/veo/AssetLibrary.tsx
@@ -237,8 +237,9 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
             <button
                 onClick={onRemove}
                 type="button"
-                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100">
-                <XMarkIcon className="w-3 h-3" />
+                aria-label="Remove asset"
+                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none transition-all border border-white/10 scale-90 group-hover:scale-100">
+                <XMarkIcon className="w-3 h-3" aria-hidden="true" />
             </button>
 
             <div className="aspect-[4/3] bg-black/40 relative overflow-hidden">
@@ -261,11 +262,12 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
                     </label>
                 )}
                 {asset.image && (
-                    <label className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-md p-2 rounded-full cursor-pointer hover:bg-indigo-600 border border-white/10 opacity-0 group-hover:opacity-100 transition-all scale-75 group-hover:scale-100">
-                        <UploadCloudIcon className="w-3 h-3 text-white" />
+                    <label className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-md p-2 rounded-full cursor-pointer hover:bg-indigo-600 border border-white/10 opacity-0 group-hover:opacity-100 focus-within:opacity-100 focus-within:ring-2 focus-within:ring-background/50 focus-within:outline-none focus-within:scale-100 transition-all scale-75 group-hover:scale-100">
+                        <UploadCloudIcon className="w-3 h-3 text-white" aria-hidden="true" />
+                        <span className="sr-only">Upload new image for {asset.name}</span>
                         <input
                             type="file"
-                            className="hidden"
+                            className="opacity-0 absolute inset-0 cursor-pointer w-full h-full"
                             onChange={onUpload}
                             accept="image/png, image/jpeg, image/webp"
                         />

--- a/frontend_v2/src/components/veo/ShotCard.tsx
+++ b/frontend_v2/src/components/veo/ShotCard.tsx
@@ -95,14 +95,14 @@ const ShotCard: React.FC<ShotCardProps> = ({
                         <pre className="text-indigo-400/80 leading-relaxed">
                             <code>{shot.veoJson ? JSON.stringify(shot.veoJson, null, 2) : '// Awaiting Director Breakdown...'}</code>
                         </pre>
-                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-all translate-y-2 group-hover:translate-y-0">
+                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 focus-within:translate-y-0 transition-all translate-y-2 group-hover:translate-y-0">
                             <button
                                 onClick={() => {
                                     navigator.clipboard.writeText(JSON.stringify(shot.veoJson, null, 2));
                                     setCopyButtonText('Copied!');
                                     setTimeout(() => setCopyButtonText('Copy JSON'), 2000);
                                 }}
-                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all"
+                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"
                             >
                                 {copyButtonText}
                             </button>


### PR DESCRIPTION
💡 **What**:
The UX enhancement added keyboard accessibility to interactive actions that were previously only revealed via mouse hover (`opacity-0 group-hover:opacity-100`).

🎯 **Why**:
Users navigating via keyboard (such as those using screen readers or relying on Tab navigation) could not see or properly focus these secondary actions (e.g., removing an asset, uploading an image, copying JSON) because they remained hidden or invisible. This solves a major accessibility gap for critical secondary workflows.

📸 **Before/After**:
Before, pressing "Tab" over the asset cards or JSON areas provided no visual feedback, leaving the user guessing where their focus was.
After, pressing "Tab" smoothly reveals the hidden buttons and highlights them with a standard blue focus ring.

♿ **Accessibility**:
- Utilized `focus-within:opacity-100` on containers to reveal child actions.
- Added `focus-visible:ring-2` to buttons for clear focus indication.
- Replaced `className="hidden"` on file inputs with `opacity-0 absolute inset-0` to keep them focusable while visually hidden.
- Added `aria-label` and `aria-hidden` attributes to icon-only buttons.

---
*PR created automatically by Jules for task [16623819289614505687](https://jules.google.com/task/16623819289614505687) started by @thebearwithabite*