### PR TITLE
⚡ Bolt: Enable memory-mapped I/O in local metadata store

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2025-05-27 - [Bulk SQLite Inserts and Connection Reuse for Tagging]
 **Learning:** Sequential `.execute` calls for `INSERT OR REPLACE` inside nested loops over large arrays (like tags) coupled with opening independent DB connections per method creates a severe N+1 problem. Benchmarks showed replacing it with a single shared connection and `executemany` arrays resulted in an ~2x speedup on typical batch tagging workloads.
 **Action:** Always batch related SQL records using `.executemany()` and pass an optional `db_connection` downstream to nested operations instead of establishing a new database connection every time.
+## 2026-03-27 - Silently Failing PRAGMA Configurations Disable SQLite Performance Features
+**Learning:** Invalid `PRAGMA` values (like string `XXXXXXXXX` for `mmap_size`) fail silently in SQLite and can silently disable critical performance features like memory-mapped I/O, degrading database performance without generating obvious errors or warnings.
+**Action:** Always ensure that SQLite `PRAGMA` settings that expect integers (like byte sizes) are passed valid integer values to guarantee the expected performance improvements are active.

--- a/local_metadata_store.py
+++ b/local_metadata_store.py
@@ -162,7 +162,7 @@ class LocalMetadataStore:
             self._local.connection.execute("PRAGMA synchronous=NORMAL")  
             self._local.connection.execute("PRAGMA cache_size=10000")
             self._local.connection.execute("PRAGMA temp_store=MEMORY")
-            self._local.connection.execute("PRAGMA mmap_size=XXXXXXXXX")  # 256MB
+            self._local.connection.execute("PRAGMA mmap_size=268435456")  # 256MB
             
             # Enable foreign keys
             self._local.connection.execute("PRAGMA foreign_keys=ON")


### PR DESCRIPTION
💡 **What**: Changed `PRAGMA mmap_size=XXXXXXXXX` to `PRAGMA mmap_size=268435456` in `local_metadata_store.py`.
🎯 **Why**: The invalid string placeholder (`XXXXXXXXX`) was failing silently in SQLite, which disabled memory-mapped I/O. Using a valid integer (256MB) allows SQLite to map the database file into memory, significantly reducing I/O overhead and bypassing the OS page cache for direct memory access.
📊 **Impact**: Noticeably improves read performance for the metadata database, particularly during intensive scanning and searching operations.
🔬 **Measurement**: Validated configuration by ensuring the database initializes correctly via `test_metadata.py` and reviewing logs for execution errors. The silent failure behavior of invalid SQLite pragmas was added to the critical learnings journal (`.jules/bolt.md`).

---
*PR created automatically by Jules for task [2650762019896218806](https://jules.google.com/task/2650762019896218806) started by @thebearwithabite*