### PR TITLE
🛡️ Sentinel: Fix SQL injection in metadata_generator.py

### DIFF
--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -467,9 +467,20 @@ class MetadataGenerator:
         
         try:
             with sqlite3.connect(self.db_path) as conn:
+                # Security: prevent SQL injection by validating column names against schema
+                cursor = conn.execute("PRAGMA table_info(file_metadata)")
+                valid_columns = {row[1] for row in cursor.fetchall()}
+
+                # Filter metadata to only include valid columns
+                safe_metadata = {k: v for k, v in metadata.items() if k in valid_columns}
+
+                if not safe_metadata:
+                    print("Warning: No valid columns found in metadata to save.")
+                    return False
+
                 # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                columns = list(safe_metadata.keys())
+                values = list(safe_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SQL injection in metadata generator

🚨 Severity: CRITICAL
💡 Vulnerability: Unsanitized keys from the `metadata` dictionary were being concatenated to construct the column names for a dynamic `INSERT OR REPLACE` SQL query.
🎯 Impact: Attackers could inject arbitrary SQL statements (like `DROP TABLE`) into the database if they had any control over the incoming metadata.
🔧 Fix: Fetches the valid columns from the database schema using `PRAGMA table_info` and safely filters out any untrusted keys before executing the query.
✅ Verification: Ran `python3 test_metadata.py` and validated that metadata functionality still executes smoothly without regression.

---
*PR created automatically by Jules for task [9971791977562550324](https://jules.google.com/task/9971791977562550324) started by @thebearwithabite*