### PR TITLE
🎨 Palette: Make hover-only actions keyboard accessible in Veo components

### DIFF
--- a/frontend_v2/src/components/veo/AssetLibrary.tsx
+++ b/frontend_v2/src/components/veo/AssetLibrary.tsx
@@ -237,8 +237,9 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
             <button
                 onClick={onRemove}
                 type="button"
-                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100">
-                <XMarkIcon className="w-3 h-3" />
+                aria-label="Remove asset"
+                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100 focus-visible:scale-100 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none">
+                <XMarkIcon className="w-3 h-3" aria-hidden="true" />
             </button>
 
             <div className="aspect-[4/3] bg-black/40 relative overflow-hidden">
@@ -254,18 +255,18 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
                         <span className="text-[9px] font-black uppercase text-white/20 tracking-widest group-hover/upload:text-indigo-400">Upload Still</span>
                         <input
                             type="file"
-                            className="hidden"
+                            className="sr-only focus-visible:outline-none"
                             onChange={onUpload}
                             accept="image/png, image/jpeg, image/webp"
                         />
                     </label>
                 )}
                 {asset.image && (
-                    <label className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-md p-2 rounded-full cursor-pointer hover:bg-indigo-600 border border-white/10 opacity-0 group-hover:opacity-100 transition-all scale-75 group-hover:scale-100">
+                    <label className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-md p-2 rounded-full cursor-pointer hover:bg-indigo-600 border border-white/10 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-all scale-75 group-hover:scale-100 focus-within:scale-100 focus-within:ring-2 focus-within:ring-indigo-500 focus-within:outline-none">
                         <UploadCloudIcon className="w-3 h-3 text-white" />
                         <input
                             type="file"
-                            className="hidden"
+                            className="sr-only focus-visible:outline-none"
                             onChange={onUpload}
                             accept="image/png, image/jpeg, image/webp"
                         />

--- a/frontend_v2/src/components/veo/ShotCard.tsx
+++ b/frontend_v2/src/components/veo/ShotCard.tsx
@@ -95,14 +95,15 @@ const ShotCard: React.FC<ShotCardProps> = ({
                         <pre className="text-indigo-400/80 leading-relaxed">
                             <code>{shot.veoJson ? JSON.stringify(shot.veoJson, null, 2) : '// Awaiting Director Breakdown...'}</code>
                         </pre>
-                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-all translate-y-2 group-hover:translate-y-0">
+                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-all translate-y-2 group-hover:translate-y-0 focus-within:translate-y-0">
                             <button
                                 onClick={() => {
                                     navigator.clipboard.writeText(JSON.stringify(shot.veoJson, null, 2));
                                     setCopyButtonText('Copied!');
                                     setTimeout(() => setCopyButtonText('Copy JSON'), 2000);
                                 }}
-                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all"
+                                aria-label="Copy JSON"
+                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none"
                             >
                                 {copyButtonText}
                             </button>


### PR DESCRIPTION
💡 What: Fixed keyboard accessibility for several UI actions hidden behind hover states.
🎯 Why: Elements like the "Remove Asset", "Upload Still", and "Copy JSON" buttons used `opacity-0 group-hover:opacity-100` and `hidden` inputs, rendering them completely inaccessible to keyboard-only users navigating via the Tab key.
♿ Accessibility:
- Replaced `hidden` with `sr-only` on file inputs to maintain screen reader support while allowing focus.
- Added `focus-within:opacity-100` to containers revealing elements when focused.
- Added `focus-visible:opacity-100 focus-visible:ring-2` to buttons to ensure focus rings are visible when revealed by keyboard navigation.

---
*PR created automatically by Jules for task [10972120304188997981](https://jules.google.com/task/10972120304188997981) started by @thebearwithabite*