### PR TITLE
🎨 Palette: Make hover-only info tooltips keyboard accessible

### DIFF
--- a/frontend_v2/src/components/dashboard/DiskSpaceWidget.tsx
+++ b/frontend_v2/src/components/dashboard/DiskSpaceWidget.tsx
@@ -102,9 +102,11 @@ export default function DiskSpaceWidget() {
       <div className="flex items-center gap-2 mb-4">
         <HardDrive size={20} className="text-purple-400" />
         <h2 className="text-xl font-semibold text-white">Disk Space Protection</h2>
-        <div className="group relative ml-auto">
-          <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" />
-          <div className="invisible group-hover:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
+        <div className="relative ml-auto">
+          <button type="button" className="peer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-full flex" aria-label="Disk space protection info">
+            <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" aria-hidden="true" />
+          </button>
+          <div role="tooltip" className="invisible peer-hover:visible peer-focus:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
             Monitors disk space and prevents "disk full" crises. Automatically protects against space issues before they happen. ADHD-friendly: eliminates panic moments from sudden space issues.
           </div>
         </div>

--- a/frontend_v2/src/components/dashboard/MonitorStatusWidget.tsx
+++ b/frontend_v2/src/components/dashboard/MonitorStatusWidget.tsx
@@ -80,9 +80,11 @@ export default function MonitorStatusWidget() {
       <div className="flex items-center gap-2 mb-4">
         <Activity size={20} className={isActive ? 'text-success' : 'text-white/40'} />
         <h2 className="text-xl font-semibold text-white">Background Monitor</h2>
-        <div className="group relative ml-auto">
-          <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" />
-          <div className="invisible group-hover:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
+        <div className="relative ml-auto">
+          <button type="button" className="peer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-full flex" aria-label="Background monitor info">
+            <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" aria-hidden="true" />
+          </button>
+          <div role="tooltip" className="invisible peer-hover:visible peer-focus:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
             Watches your Downloads and Desktop folders for new files. Learns from your manual file movements (7-day cooldown rule applies). ADHD-friendly: works silently in the background without interruptions.
           </div>
         </div>

--- a/frontend_v2/src/pages/Duplicates.tsx
+++ b/frontend_v2/src/pages/Duplicates.tsx
@@ -209,9 +209,11 @@ export default function Duplicates() {
                     </div>
                   </div>
                 </div>
-                <div className="group relative">
-                  <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" />
-                  <div className="invisible group-hover:visible absolute right-0 top-6 w-64 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
+                <div className="relative">
+                  <button type="button" className="peer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-full flex" aria-label="Duplicate cleaning info">
+                    <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" aria-hidden="true" />
+                  </button>
+                  <div role="tooltip" className="invisible peer-hover:visible peer-focus:visible absolute right-0 top-6 w-64 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
                     Select which file to keep, then clean the rest. All operations can be undone via Settings → Rollback.
                   </div>
                 </div>


### PR DESCRIPTION
🎨 Palette: Make hover-only info tooltips keyboard accessible

💡 What: Wrapped `<Info>` icons in `<button>` elements with `peer` classes and added `peer-focus:visible` to their respective tooltip containers in `DiskSpaceWidget`, `MonitorStatusWidget`, and `Duplicates`.
🎯 Why: Actions or information hidden behind `group-hover:visible` are completely inaccessible to keyboard-only users navigating via Tab. This ensures the helpful tooltips can be read by everyone.
♿ Accessibility:
- Added `<button type="button">` to make the icons focusable in the tab order.
- Added descriptive `aria-label` to the buttons.
- Added `aria-hidden="true"` to the decorative icon SVGs.
- Added `role="tooltip"` to the popup containers.
- Added clear `focus-visible:ring-2 focus-visible:ring-primary` focus indicators.
- Used `peer-hover:visible peer-focus:visible` to reveal the tooltip on both mouse hover and keyboard focus.

---
*PR created automatically by Jules for task [9908807227216133555](https://jules.google.com/task/9908807227216133555) started by @thebearwithabite*