### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in metadata generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,14 @@
 **Prevention:**
 1. Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
 2. Absolute paths always begin with a directory separator (`/` on Unix) or a drive letter (`C:\` on Windows), guaranteeing the command-line tool parses them as file paths rather than flags or options.
+
+## 2024-05-30 - SQL Injection via Dictionary Keys in Dynamic Queries
+
+**Vulnerability:** In `metadata_generator.py`, the `save_file_metadata` method dynamically constructed an `INSERT OR REPLACE INTO` query using unvalidated keys from the `metadata` dictionary as column names. This exposed the application to SQL injection, as an attacker controlling the dictionary keys could inject arbitrary SQL into the query string (e.g., `key) VALUES (...); DROP TABLE --`).
+
+**Learning:** When building dynamic SQL queries based on dictionary keys (e.g., for inserts or updates), standard parameterization (`?` placeholders) only protects the values, not the structural elements like column names. You cannot rely on the source of the dictionary being safe.
+
+**Prevention:**
+1. Explicitly fetch the allowed schema (e.g., via `PRAGMA table_info(table_name)`) to establish a whitelist of safe column names.
+2. Filter the input dictionary to strictly include only keys that match the whitelisted columns before generating the query string.
+3. This neutralizes injection vectors and gracefully ignores unrecognized metadata keys.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -467,9 +467,20 @@ class MetadataGenerator:
         
         try:
             with sqlite3.connect(self.db_path) as conn:
+                # Fetch safe column names to prevent SQL injection via keys
+                cursor = conn.execute("PRAGMA table_info(file_metadata)")
+                safe_columns = {row[1] for row in cursor.fetchall()}
+
+                # Filter metadata to only include safe columns
+                safe_metadata = {k: v for k, v in metadata.items() if k in safe_columns}
+
+                if not safe_metadata:
+                    print("Error saving metadata: No valid columns provided")
+                    return False
+
                 # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                columns = list(safe_metadata.keys())
+                values = list(safe_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SQL injection in metadata generation

🚨 Severity: CRITICAL
💡 Vulnerability: SQL Injection via Dictionary Keys in Dynamic Queries
🎯 Impact: An attacker or malformed data source could inject arbitrary SQL into the `save_file_metadata` method by providing malicious dictionary keys (e.g., `column_name) VALUES (...); DROP TABLE...`). This could lead to data loss, modification, or exposure of the entire `file_metadata` table.
🔧 Fix: Fetched the exact table schema using `PRAGMA table_info(file_metadata)` and strictly whitelisted the incoming `metadata` keys against the safe column names before generating the dynamic SQL query.
✅ Verification: Tested manually with a mock script simulating a malicious key containing `ON CONFLICT DO UPDATE`. After the fix, the malicious key was safely ignored and filtered out before query execution.

---
*PR created automatically by Jules for task [8645368814105378902](https://jules.google.com/task/8645368814105378902) started by @thebearwithabite*