### PR TITLE
⚡ Bolt: Enable SQLite Memory-Mapped I/O for Local Metadata Store

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2025-05-27 - [Bulk SQLite Inserts and Connection Reuse for Tagging]
 **Learning:** Sequential `.execute` calls for `INSERT OR REPLACE` inside nested loops over large arrays (like tags) coupled with opening independent DB connections per method creates a severe N+1 problem. Benchmarks showed replacing it with a single shared connection and `executemany` arrays resulted in an ~2x speedup on typical batch tagging workloads.
 **Action:** Always batch related SQL records using `.executemany()` and pass an optional `db_connection` downstream to nested operations instead of establishing a new database connection every time.
+
+## 2025-05-28 - [Validating SQLite PRAGMAs]
+**Learning:** Invalid PRAGMA configuration values in SQLite (e.g., passing a string 'XXXXXXXXX' to `mmap_size` instead of an integer) fail silently without throwing an exception. This led to memory-mapped I/O being completely disabled despite the PRAGMA execution block appearing correct, leaving significant performance on the table.
+**Action:** Always verify PRAGMA statements are using correct types (especially integers vs strings) since SQLite won't warn you when they are ignored.

--- a/local_metadata_store.py
+++ b/local_metadata_store.py
@@ -162,7 +162,7 @@ class LocalMetadataStore:
             self._local.connection.execute("PRAGMA synchronous=NORMAL")  
             self._local.connection.execute("PRAGMA cache_size=10000")
             self._local.connection.execute("PRAGMA temp_store=MEMORY")
-            self._local.connection.execute("PRAGMA mmap_size=XXXXXXXXX")  # 256MB
+            self._local.connection.execute("PRAGMA mmap_size=268435456")  # 256MB
             
             # Enable foreign keys
             self._local.connection.execute("PRAGMA foreign_keys=ON")


### PR DESCRIPTION
💡 **What:** Replaced the invalid string `'XXXXXXXXX'` with the integer `268435456` in `local_metadata_store.py` for `PRAGMA mmap_size`. Added a journal entry logging the learning.

🎯 **Why:** Invalid PRAGMA values in SQLite fail silently. Because of the string placeholder, the database wasn't actually enabling memory-mapped I/O as intended by the developer (comment `# 256MB`). Enabling `mmap_size` optimizes I/O and speeds up database reads, which is crucial for a local metadata store.

📊 **Impact:** Properly enables memory-mapped I/O for up to 256MB of database file size, drastically reducing memory copy overhead during read operations.

🔬 **Measurement:** Code was verified manually using a temporary script to test `PRAGMA mmap_size` behavior, confirming that a string sets it to 0 and an integer sets it to the intended value.

---
*PR created automatically by Jules for task [5005377279755165471](https://jules.google.com/task/5005377279755165471) started by @thebearwithabite*