### PR TITLE
🎨 Palette: Improve accessibility of ClassificationPreview action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-16 - Make hover-only actions keyboard accessible
 **Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
 **Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.
+
+## 2024-03-30 - Screen Reader Accessibility for Icon-Only Action Buttons
+**Learning:** Action buttons composed exclusively of decorative or functional icons (e.g., Lucide React icons like X, Loader2, Check) inside of status/preview dialogs often lack sufficient text context, causing screen readers to announce them cryptically as just "button".
+**Action:** Always apply an `aria-label` or `title` containing a clear description (e.g., "Skip organization") to the parent `<button>`, and explicitly set `aria-hidden="true"` on the child `<svg>` icon element to prevent conflicting or duplicate screen reader announcements.

--- a/frontend_v2/src/components/organize/ClassificationPreview.tsx
+++ b/frontend_v2/src/components/organize/ClassificationPreview.tsx
@@ -169,38 +169,40 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         <button
           onClick={handleConfirm}
           disabled={isConfirming}
-          className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-success hover:bg-success/90 rounded-xl font-medium transition-colors text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-success hover:bg-success/90 rounded-xl font-medium transition-colors text-white disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
         >
           {isConfirming ? (
             <>
-              <Loader2 size={20} className="animate-spin" />
+              <Loader2 size={20} className="animate-spin" aria-hidden="true" />
               Organizing...
             </>
           ) : (
             <>
-              <Check size={20} />
+              <Check size={20} aria-hidden="true" />
               Confirm & Organize
             </>
           )}
         </button>
         <button
           onClick={handleReclassify}
-          className="flex items-center justify-center gap-2 px-4 py-3 bg-white/10 hover:bg-white/20 rounded-xl font-medium transition-colors text-white"
+          className="flex items-center justify-center gap-2 px-4 py-3 bg-white/10 hover:bg-white/20 rounded-xl font-medium transition-colors text-white focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
         >
-          <RefreshCw size={20} />
+          <RefreshCw size={20} aria-hidden="true" />
           Reclassify
         </button>
         <button
           onClick={handleSkip}
-          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white"
+          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+          aria-label="Skip organization"
+          title="Skip organization"
         >
-          <X size={20} />
+          <X size={20} aria-hidden="true" />
         </button>
       </div>
 
       <button
         onClick={handleSkip}
-        className="w-full mt-3 text-sm text-white/60 hover:text-white transition-colors"
+        className="w-full mt-3 text-sm text-white/60 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 rounded"
       >
         Skip (organize later)
       </button>


### PR DESCRIPTION
🎨 **Palette UX/A11y Enhancement**

This PR focuses on a micro-UX improvement for the `ClassificationPreview` component, specifically targeting screen reader and keyboard navigation accessibility.

**💡 What:**
* Added an `aria-label="Skip organization"` to the icon-only close (`X`) button.
* Added `aria-hidden="true"` to the decorative Lucide React icons within the action buttons (`Loader2`, `Check`, `RefreshCw`, `X`).
* Applied consistent `focus-visible:ring-2` (and related outline/offset utilities) to all action buttons.
* Updated `.jules/palette.md` to document the learning.

**🎯 Why:**
* **Screen Readers:** Previously, the "Skip" button was just an `X` icon, meaning a screen reader would announce it unhelpfully as "button". Adding the `aria-label` provides necessary context. Adding `aria-hidden` to the SVG icons prevents the screen reader from trying to read out the SVG paths or duplicate the button's text label.
* **Keyboard Navigation:** While mouse users easily understand button bounds, keyboard users rely on focus states. The standard Tailwind classes didn't provide a strong enough visual indicator when tabbing through the `ClassificationPreview` modal. The `focus-visible` classes ensure a clear ring appears.

**📸 Before/After:**
* Visual changes are isolated to focus states. When tabbing to the Confirm, Reclassify, or Skip buttons, a clear white focus ring now appears.

**♿ Accessibility:**
* Improved semantics for screen reader users.
* Improved visual focus indicators for keyboard users.

---
*PR created automatically by Jules for task [7480254534820878181](https://jules.google.com/task/7480254534820878181) started by @thebearwithabite*