### PR TITLE
🎨 Palette: Add ARIA labels and focus states to VeoProjectForm buttons

### DIFF
--- a/frontend_v2/src/components/veo/VeoProjectForm.tsx
+++ b/frontend_v2/src/components/veo/VeoProjectForm.tsx
@@ -103,8 +103,8 @@ const VeoProjectForm: React.FC<VeoProjectFormProps> = ({
                     <div className="flex justify-between items-center mb-8 relative z-10">
                         <p className="text-[11px] text-white/40 font-bold uppercase tracking-widest leading-none">Draft your scene beats or upload a screenplay</p>
                         <div className="flex gap-2">
-                            <button type="button" onClick={() => scriptFileInputRef.current?.click()} className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileUploadIcon className="w-4 h-4" /></button>
-                            <button type="button" className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileAudioIcon className="w-4 h-4" /></button>
+                            <button aria-label="Upload Script" type="button" onClick={() => scriptFileInputRef.current?.click()} className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"><FileUploadIcon aria-hidden="true" className="w-4 h-4" /></button>
+                            <button aria-label="Upload Audio" type="button" className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"><FileAudioIcon aria-hidden="true" className="w-4 h-4" /></button>
                         </div>
                     </div>
 


### PR DESCRIPTION
💡 **What**: Added ARIA labels and focus states to the script and audio upload icon-only buttons in `VeoProjectForm.tsx`.
🎯 **Why**: These buttons were purely visual (icons only) and had no text, making them completely inaccessible to screen readers. Furthermore, keyboard users tabbing through the interface had no visual indication of when these buttons were focused.
📸 **Before/After**: See the attached playwright UI test artifacts. When tabbing to the buttons, they now display a proper focus ring.
♿ **Accessibility**: 
- Added `aria-label` to provide explicit names for screen readers.
- Added `aria-hidden="true"` to the inner decorative SVG icons.
- Implemented `focus-visible:ring-2 focus-visible:ring-background/50` for clear keyboard navigation cues.

---
*PR created automatically by Jules for task [14959735574219498419](https://jules.google.com/task/14959735574219498419) started by @thebearwithabite*