### PR TITLE
🎨 Palette: Improve screen reader accessibility for AssetCard buttons

### DIFF
--- a/frontend_v2/src/components/veo/AssetLibrary.tsx
+++ b/frontend_v2/src/components/veo/AssetLibrary.tsx
@@ -237,8 +237,9 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
             <button
                 onClick={onRemove}
                 type="button"
+                aria-label="Remove asset"
                 className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100">
-                <XMarkIcon className="w-3 h-3" />
+                <XMarkIcon className="w-3 h-3" aria-hidden="true" />
             </button>
 
             <div className="aspect-[4/3] bg-black/40 relative overflow-hidden">
@@ -290,8 +291,9 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
                         type="button"
                         onClick={handleCopyDescription}
                         className="text-white/20 hover:text-white transition-colors flex-shrink-0 mt-0.5"
-                        title="Copy Name & Description">
-                        {copied ? <CheckCircle2Icon className="w-3 h-3 text-green-400" /> : <ClipboardDocumentIcon className="w-3 h-3" />}
+                        title="Copy Name & Description"
+                        aria-label="Copy Name & Description">
+                        {copied ? <CheckCircle2Icon className="w-3 h-3 text-green-400" aria-hidden="true" /> : <ClipboardDocumentIcon className="w-3 h-3" aria-hidden="true" />}
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the "Remove" and "Copy Name & Description" icon-only buttons within the `AssetCard` component in `AssetLibrary.tsx`. Also added `aria-hidden="true"` to the inner SVG icons.
🎯 Why: Without text labels, screen readers announce these buttons generically (often just as "button"), providing no context for visually impaired users. This micro-UX change ensures the buttons' actions are clearly communicated.
♿ Accessibility: Improved screen reader compatibility by explicitly defining button purposes and hiding decorative child SVGs from the accessibility tree.

---
*PR created automatically by Jules for task [13999562692650723145](https://jules.google.com/task/13999562692650723145) started by @thebearwithabite*