### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL Injection in Metadata Generator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Prevention:**
 1. Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
 2. Absolute paths always begin with a directory separator (`/` on Unix) or a drive letter (`C:\` on Windows), guaranteeing the command-line tool parses them as file paths rather than flags or options.
+## 2024-05-18 - Prevent SQL Injection in Dynamic Column Names
+**Vulnerability:** SQL injection vulnerability in `metadata_generator.py` where `metadata` dictionary keys were directly interpolated into an `INSERT OR REPLACE` statement without validation.
+**Learning:** Even when parameterized queries (`?`) are used for values, dynamically generated column names are still vulnerable if the source (dictionary keys) can be manipulated or is untrusted.
+**Prevention:** Use an explicit schema allowlist (e.g., fetching `PRAGMA table_info` from the database) to filter dictionary keys and prevent SQL injection before constructing the query.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -467,9 +467,20 @@ class MetadataGenerator:
         
         try:
             with sqlite3.connect(self.db_path) as conn:
+                # Get valid columns to prevent SQL injection
+                cursor = conn.execute("PRAGMA table_info(file_metadata)")
+                valid_columns = {row[1] for row in cursor.fetchall()}
+
+                # Filter metadata to only include valid columns
+                filtered_metadata = {k: v for k, v in metadata.items() if k in valid_columns}
+
+                if not filtered_metadata:
+                    print("Error: No valid metadata columns found to save.")
+                    return False
+
                 # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                columns = list(filtered_metadata.keys())
+                values = list(filtered_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: SQL injection vulnerability in `metadata_generator.py`. The `save_file_metadata` method constructed a SQL `INSERT OR REPLACE` query by directly interpolating the keys from the `metadata` dictionary into the query string as column names. This bypassed parameterization and allowed potential execution of arbitrary SQL if an attacker could control the keys of the `metadata` dictionary.
🎯 **Impact**: Allowed execution of arbitrary SQL statements on the database, which could lead to data leakage, modification, or complete database destruction.
🔧 **Fix**: Implemented an explicit schema allowlist. The code now dynamically queries SQLite's `PRAGMA table_info` to get the actual column names of the `file_metadata` table, and then filters the untrusted `metadata` dictionary keys to ensure only valid columns are included in the SQL statement.
✅ **Verification**: Run `python3 test_metadata.py` to ensure normal functionality works correctly. A local test script verified that the vulnerable behavior has been stopped and no errors are raised for invalid columns.

---
*PR created automatically by Jules for task [6663360943278694884](https://jules.google.com/task/6663360943278694884) started by @thebearwithabite*