### PR TITLE
⚡ Bolt: Enable SQLite Memory-Mapped I/O in Metadata Store

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2025-05-27 - [Bulk SQLite Inserts and Connection Reuse for Tagging]
 **Learning:** Sequential `.execute` calls for `INSERT OR REPLACE` inside nested loops over large arrays (like tags) coupled with opening independent DB connections per method creates a severe N+1 problem. Benchmarks showed replacing it with a single shared connection and `executemany` arrays resulted in an ~2x speedup on typical batch tagging workloads.
 **Action:** Always batch related SQL records using `.executemany()` and pass an optional `db_connection` downstream to nested operations instead of establishing a new database connection every time.
+
+## 2025-05-28 - [Fixing Invalid SQLite PRAGMA Values]
+**Learning:** In SQLite configurations within the project, `PRAGMA mmap_size` must be set to a valid integer byte size (e.g., `268435456` for 256MB). Invalid strings fail silently and disable memory-mapped I/O.
+**Action:** Always verify PRAGMA values are correct integers and test database configurations directly.

--- a/local_metadata_store.py
+++ b/local_metadata_store.py
@@ -162,7 +162,7 @@ class LocalMetadataStore:
             self._local.connection.execute("PRAGMA synchronous=NORMAL")  
             self._local.connection.execute("PRAGMA cache_size=10000")
             self._local.connection.execute("PRAGMA temp_store=MEMORY")
-            self._local.connection.execute("PRAGMA mmap_size=XXXXXXXXX")  # 256MB
+            self._local.connection.execute("PRAGMA mmap_size=268435456")  # 256MB
             
             # Enable foreign keys
             self._local.connection.execute("PRAGMA foreign_keys=ON")


### PR DESCRIPTION
💡 What: Replaced an invalid literal string `"XXXXXXXXX"` with the correct integer value `268435456` for `PRAGMA mmap_size` in `local_metadata_store.py`.
🎯 Why: SQLite configurations must use valid integer values. An invalid string causes SQLite to fail silently and disable memory-mapped I/O, negating intended performance benefits.
📊 Impact: Expected performance improvement in database read operations, enabling the 256MB memory mapping intended by the original design.
🔬 Measurement: Verify with `grep` that `PRAGMA mmap_size` is now correctly set to `268435456` in `local_metadata_store.py`.

---
*PR created automatically by Jules for task [18028057969174997367](https://jules.google.com/task/18028057969174997367) started by @thebearwithabite*