### PR TITLE
⚡ Bolt: Combine SQLite COUNT aggregations in learning_report.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2025-05-27 - [Bulk SQLite Inserts and Connection Reuse for Tagging]
 **Learning:** Sequential `.execute` calls for `INSERT OR REPLACE` inside nested loops over large arrays (like tags) coupled with opening independent DB connections per method creates a severe N+1 problem. Benchmarks showed replacing it with a single shared connection and `executemany` arrays resulted in an ~2x speedup on typical batch tagging workloads.
 **Action:** Always batch related SQL records using `.executemany()` and pass an optional `db_connection` downstream to nested operations instead of establishing a new database connection every time.
+
+## 2025-10-24 - [Combine Database Aggregation Queries]
+**Learning:** Performing multiple sequential `COUNT` queries on the same table causes unnecessary N+1 full table or index scans, reducing I/O throughput. However, combining them using `COALESCE(SUM(CASE WHEN...))` reduces readability without performance gains over `COUNT` with conditionals in SQLite. Combining multiple metric gatherings into a single query using `COUNT(CASE WHEN ... THEN 1 END)` is both performant and readable.
+**Action:** When gathering multiple metrics (total count, conditional counts) from the same table, combine them into a single `SELECT` statement using `COUNT(CASE WHEN condition THEN 1 END)`.

--- a/learning_report.py
+++ b/learning_report.py
@@ -27,9 +27,15 @@ def generate_report():
             conn.row_factory = sqlite3.Row
             
             # 1. High Level Stats
-            total_events = conn.execute("SELECT COUNT(*) FROM learning_events").fetchone()[0]
-            verified_events = conn.execute("SELECT COUNT(*) FROM learning_events WHERE event_type IN ('user_correction', 'manual_move', 'preference_update', 'user_confirmed')").fetchone()[0]
-            observations = conn.execute("SELECT COUNT(*) FROM learning_events WHERE event_type = 'ai_observation'").fetchone()[0]
+            # Optimized: Combine multiple COUNT queries into a single query using COUNT over conditionals to eliminate redundant full table scans
+            cursor = conn.execute("""
+                SELECT
+                    COUNT(*),
+                    COUNT(CASE WHEN event_type IN ('user_correction', 'manual_move', 'preference_update', 'user_confirmed') THEN 1 END),
+                    COUNT(CASE WHEN event_type = 'ai_observation' THEN 1 END)
+                FROM learning_events
+            """)
+            total_events, verified_events, observations = cursor.fetchone()
             
             print(f"📈 Knowledge Base Stats:")
             print(f"   Total Learning Events:  {total_events}")


### PR DESCRIPTION
💡 What: Refactored `generate_report` in `learning_report.py` to combine three sequential `SELECT COUNT(*)` queries on the `learning_events` table into a single query using conditional aggregation (`COUNT(CASE WHEN ...)`).
🎯 Why: Multiple sequential aggregations on the same table cause redundant full table or index scans (an N+1 problem for table reads), reducing I/O throughput. Combining them into a single query requires only one pass over the data.
📊 Impact: Reduces database reads for the learning events base metrics by 66% (from 3 table scans to 1). The actual measurable impact will scale proportionally with the size of the `learning_events` table.
🔬 Measurement: Verify visually via the output of `generate_report` that the Knowledge Base Stats continue to produce the correct counts, or by isolating the `SQL` logic in a mock execution.

---
*PR created automatically by Jules for task [102955351666156684](https://jules.google.com/task/102955351666156684) started by @thebearwithabite*