### PR TITLE
🎨 Palette: Make dynamic loading text accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-16 - Make hover-only actions keyboard accessible
 **Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
 **Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.
+
+## 2024-05-20 - Accessible Cycling Text Elements
+**Learning:** Dynamically changing text elements (like cycling loading messages) are silently updated and ignored by screen readers, leaving visually impaired users unaware of progress or status changes.
+**Action:** Always apply `aria-live="polite"` and `aria-atomic="true"` to dynamically updating text containers to ensure screen readers announce the changing content without unnecessarily interrupting the user.

--- a/frontend_v2/src/components/veo/LoadingIndicator.tsx
+++ b/frontend_v2/src/components/veo/LoadingIndicator.tsx
@@ -36,7 +36,11 @@ const LoadingIndicator: React.FC = () => {
             <h2 className="text-2xl font-black mt-8 text-white italic tracking-tighter">
                 Generating Your Shot Book
             </h2>
-            <p className="mt-2 text-white/50 text-center transition-opacity duration-500 font-medium">
+            <p
+                className="mt-2 text-white/50 text-center transition-opacity duration-500 font-medium"
+                aria-live="polite"
+                aria-atomic="true"
+            >
                 {loadingMessages[messageIndex]}
             </p>
         </div>


### PR DESCRIPTION
I've added a small UX/accessibility enhancement to `frontend_v2/src/components/veo/LoadingIndicator.tsx`.

The `LoadingIndicator` component cycles through a list of loading messages every few seconds. However, this dynamically changing text was inaccessible to screen readers because it lacked the appropriate ARIA live region attributes.

I've added `aria-live="polite"` and `aria-atomic="true"` to the `<p>` tag containing the text. This is a crucial micro-UX improvement that ensures screen reader users are properly informed of the changing loading status without being overly interrupted.

I also added an entry to `.jules/palette.md` to document this critical learning regarding dynamically changing text elements.

Tested by running `pnpm build` in `frontend_v2`.

---
*PR created automatically by Jules for task [10568401861781719632](https://jules.google.com/task/10568401861781719632) started by @thebearwithabite*