### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix potential SQL injection in `metadata_generator.py`

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,19 @@
 **Prevention:**
 1. Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
 2. Absolute paths always begin with a directory separator (`/` on Unix) or a drive letter (`C:\` on Windows), guaranteeing the command-line tool parses them as file paths rather than flags or options.
+
+## 2024-05-30 - Widespread Argument Injection Vulnerability in File Operations
+
+**Vulnerability:** Several modules (`system_storage_cleanup.py`, `dev-archive/emergency_bulk_staging.py`, `dev-archive/repair_mislabeled_jsons.py`) passed unvalidated `pathlib.Path` strings directly to `subprocess.run` calls (e.g., for `du`, `rm`, `file`). If an attacker controlled the filename, they could name a file starting with `-` (e.g., `-rf`), leading to argument injection.
+
+**Learning:** The argument injection vulnerability found in `vision_content_extractor.py` and `main.py` is a widespread pattern in this codebase. Any invocation of external command-line tools using `subprocess.run` with user-controlled file paths must use absolute paths to prevent the tool from interpreting the filename as an option.
+
+**Prevention:** Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
+
+## 2024-05-30 - SQL Injection via unvalidated dynamic column names
+
+**Vulnerability:** The `_migrate_database_schema` function in `metadata_generator.py` uses an f-string to construct an `ALTER TABLE` query. The variables are hardcoded keys in a dictionary, however if the keys in the dictionary are user-controlled in the future, it is an avenue for SQL injection.
+
+**Learning:** When dynamically generating SQL `ALTER TABLE` statements to add columns, standard `?` parameterization does not protect column keys. You must validate the column name to prevent SQL injection.
+
+**Prevention:** Use Python's `str.isidentifier()` to validate column names and prevent SQL injection.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -231,6 +231,8 @@ class MetadataGenerator:
             migration_count = 0
             for col_name, col_type in gdrive_columns.items():
                 if col_name not in existing_columns:
+                    if not col_name.isidentifier():
+                        raise ValueError(f"Invalid column name: {col_name}")
                     conn.execute(f"ALTER TABLE file_metadata ADD COLUMN {col_name} {col_type}")
                     migration_count += 1
                     print(f"   ✅ Added column: {col_name}")


### PR DESCRIPTION
This PR implements a security enhancement to prevent potential SQL injection.

**Vulnerability:**
The `_migrate_database_schema` method in `metadata_generator.py` dynamically builds `ALTER TABLE` statements using an f-string to insert the column name. Although the dictionary keys are currently hardcoded, if they ever become user-controlled, this would introduce an SQL injection vulnerability because SQL column names cannot be parameterized with `?`.

**Fix:**
Added a check using Python's `str.isidentifier()` to validate that the column name conforms to safe syntax (alphanumeric and underscores) before executing the query. If the validation fails, a `ValueError` is raised.

**Impact:**
Increases defense-in-depth and ensures the database migration mechanism remains secure even if the schema configuration method changes in the future.

---
*PR created automatically by Jules for task [15808980851283284096](https://jules.google.com/task/15808980851283284096) started by @thebearwithabite*