### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in Veo components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-03-16 - Make hover-only actions keyboard accessible
 **Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
 **Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.
+## 2024-04-04 - Accessible icon-only buttons
+**Learning:** Added redundant `aria-label` to buttons that already have visible text can cause screen readers to read the same text twice or read out the hardcoded text instead of the visible text when it dynamically changes. The dynamic feedback is critical for accessibility.
+**Action:** Only add `aria-label` to buttons without text content, and make sure to double check that visible text is not already present before applying `aria-label`.

--- a/frontend_v2/src/components/layout/ConnectionStatus.tsx
+++ b/frontend_v2/src/components/layout/ConnectionStatus.tsx
@@ -40,9 +40,9 @@ export default function ConnectionStatus() {
             <button
                 onClick={checkConnection}
                 disabled={isChecking}
-                className="text-xs bg-background/20 hover:bg-background/30 px-2 py-1 rounded flex items-center gap-1 transition-colors"
+                className="text-xs bg-background/20 hover:bg-background/30 px-2 py-1 rounded flex items-center gap-1 transition-colors focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"
             >
-                <RefreshCw className={`h-3 w-3 ${isChecking ? 'animate-spin' : ''}`} />
+                <RefreshCw className={`h-3 w-3 ${isChecking ? 'animate-spin' : ''}`} aria-hidden="true" />
                 Retry Now
             </button>
         </div>

--- a/frontend_v2/src/components/veo/AssetLibrary.tsx
+++ b/frontend_v2/src/components/veo/AssetLibrary.tsx
@@ -237,8 +237,9 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
             <button
                 onClick={onRemove}
                 type="button"
-                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100">
-                <XMarkIcon className="w-3 h-3" />
+                aria-label="Remove Asset"
+                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100 focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none">
+                <XMarkIcon className="w-3 h-3" aria-hidden="true" />
             </button>
 
             <div className="aspect-[4/3] bg-black/40 relative overflow-hidden">
@@ -288,10 +289,11 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
                     </p>
                     <button
                         type="button"
+                        aria-label="Copy Name & Description"
                         onClick={handleCopyDescription}
-                        className="text-white/20 hover:text-white transition-colors flex-shrink-0 mt-0.5"
+                        className="text-white/20 hover:text-white transition-colors flex-shrink-0 mt-0.5 focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none rounded"
                         title="Copy Name & Description">
-                        {copied ? <CheckCircle2Icon className="w-3 h-3 text-green-400" /> : <ClipboardDocumentIcon className="w-3 h-3" />}
+                        {copied ? <CheckCircle2Icon className="w-3 h-3 text-green-400" aria-hidden="true" /> : <ClipboardDocumentIcon className="w-3 h-3" aria-hidden="true" />}
                     </button>
                 </div>
             </div>

--- a/frontend_v2/src/components/veo/ShotCard.tsx
+++ b/frontend_v2/src/components/veo/ShotCard.tsx
@@ -95,14 +95,14 @@ const ShotCard: React.FC<ShotCardProps> = ({
                         <pre className="text-indigo-400/80 leading-relaxed">
                             <code>{shot.veoJson ? JSON.stringify(shot.veoJson, null, 2) : '// Awaiting Director Breakdown...'}</code>
                         </pre>
-                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-all translate-y-2 group-hover:translate-y-0">
+                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-all translate-y-2 group-hover:translate-y-0 focus-within:translate-y-0">
                             <button
                                 onClick={() => {
                                     navigator.clipboard.writeText(JSON.stringify(shot.veoJson, null, 2));
                                     setCopyButtonText('Copied!');
                                     setTimeout(() => setCopyButtonText('Copy JSON'), 2000);
                                 }}
-                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all"
+                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"
                             >
                                 {copyButtonText}
                             </button>

--- a/frontend_v2/src/components/veo/VeoProjectForm.tsx
+++ b/frontend_v2/src/components/veo/VeoProjectForm.tsx
@@ -103,8 +103,8 @@ const VeoProjectForm: React.FC<VeoProjectFormProps> = ({
                     <div className="flex justify-between items-center mb-8 relative z-10">
                         <p className="text-[11px] text-white/40 font-bold uppercase tracking-widest leading-none">Draft your scene beats or upload a screenplay</p>
                         <div className="flex gap-2">
-                            <button type="button" onClick={() => scriptFileInputRef.current?.click()} className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileUploadIcon className="w-4 h-4" /></button>
-                            <button type="button" className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileAudioIcon className="w-4 h-4" /></button>
+                            <button type="button" aria-label="Upload Script" onClick={() => scriptFileInputRef.current?.click()} className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"><FileUploadIcon className="w-4 h-4" aria-hidden="true" /></button>
+                            <button type="button" aria-label="Upload Audio" className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"><FileAudioIcon className="w-4 h-4" aria-hidden="true" /></button>
                         </div>
                     </div>
 


### PR DESCRIPTION
### 💡 What:
Added ARIA labels, hidden standard UI icons from screen readers, and enhanced focus states for keyboard-only interaction.

### 🎯 Why:
Users relying on screen readers had no context for several icon-only buttons across the Asset Library, the Project Form, and Shot Cards. Additionally, those navigating with keyboards could not see focus rings on these items, or reach controls that were strictly hover-triggered. This fulfills the requirement for one localized micro-UX improvement that elevates application usability without large sweeping refactors.

### ♿ Accessibility:
- Added `aria-label` to icon-only buttons (e.g. Upload, Copy, Close)
- Added `aria-hidden="true"` to Lucide React / heroicons so the screen reader doesn't attempt to read generic graphics.
- Applied `focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none` to improve standard interactive component focus visibility.
- Adjusted hover groups (`focus-within`) on `ShotCard` to guarantee keyboard accessibility for formerly hidden-until-hover buttons.

---
*PR created automatically by Jules for task [6312192709857376523](https://jules.google.com/task/6312192709857376523) started by @thebearwithabite*