### PR TITLE
🎨 Palette: Make hover-only tooltips keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-03-16 - Make hover-only actions keyboard accessible
 **Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
 **Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.
+## 2024-05-23 - Keyboard Accessible Tooltips
+**Learning:** Using `group-hover` on tooltips without focus states makes them inaccessible to keyboard users.
+**Action:** Wrap the tooltip trigger icon in a focusable `<button type="button" className="peer focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none" aria-label="More information">`, add `aria-hidden="true"` to the icon, and use `peer-hover:visible peer-focus:visible` on the tooltip container (with `role="tooltip"`) to ensure proper accessibility.

--- a/frontend_v2/src/components/dashboard/DiskSpaceWidget.tsx
+++ b/frontend_v2/src/components/dashboard/DiskSpaceWidget.tsx
@@ -102,9 +102,11 @@ export default function DiskSpaceWidget() {
       <div className="flex items-center gap-2 mb-4">
         <HardDrive size={20} className="text-purple-400" />
         <h2 className="text-xl font-semibold text-white">Disk Space Protection</h2>
-        <div className="group relative ml-auto">
-          <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" />
-          <div className="invisible group-hover:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
+        <div className="relative ml-auto flex items-center">
+          <button type="button" className="peer focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none rounded-full" aria-label="More information">
+            <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" aria-hidden="true" />
+          </button>
+          <div role="tooltip" className="invisible peer-hover:visible peer-focus:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
             Monitors disk space and prevents "disk full" crises. Automatically protects against space issues before they happen. ADHD-friendly: eliminates panic moments from sudden space issues.
           </div>
         </div>

--- a/frontend_v2/src/components/dashboard/MonitorStatusWidget.tsx
+++ b/frontend_v2/src/components/dashboard/MonitorStatusWidget.tsx
@@ -80,9 +80,11 @@ export default function MonitorStatusWidget() {
       <div className="flex items-center gap-2 mb-4">
         <Activity size={20} className={isActive ? 'text-success' : 'text-white/40'} />
         <h2 className="text-xl font-semibold text-white">Background Monitor</h2>
-        <div className="group relative ml-auto">
-          <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" />
-          <div className="invisible group-hover:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
+        <div className="relative ml-auto flex items-center">
+          <button type="button" className="peer focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none rounded-full" aria-label="More information">
+            <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" aria-hidden="true" />
+          </button>
+          <div role="tooltip" className="invisible peer-hover:visible peer-focus:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
             Watches your Downloads and Desktop folders for new files. Learns from your manual file movements (7-day cooldown rule applies). ADHD-friendly: works silently in the background without interruptions.
           </div>
         </div>

--- a/frontend_v2/src/components/settings/ConfidenceModeSwitcher.tsx
+++ b/frontend_v2/src/components/settings/ConfidenceModeSwitcher.tsx
@@ -118,9 +118,11 @@ export default function ConfidenceModeSwitcher() {
       <div className="flex items-center gap-2 mb-4">
         <Sliders size={20} className="text-primary" />
         <h2 className="text-xl font-semibold text-white">Confidence Mode</h2>
-        <div className="group relative ml-auto">
-          <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" />
-          <div className="invisible group-hover:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
+        <div className="relative ml-auto flex items-center">
+          <button type="button" className="peer focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none rounded-full" aria-label="More information">
+            <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" aria-hidden="true" />
+          </button>
+          <div role="tooltip" className="invisible peer-hover:visible peer-focus:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
             Controls how often the AI asks for your input during file organization. ADHD-friendly modes help reduce decision fatigue while maintaining accuracy.
           </div>
         </div>

--- a/frontend_v2/src/components/settings/RollbackPanel.tsx
+++ b/frontend_v2/src/components/settings/RollbackPanel.tsx
@@ -143,9 +143,11 @@ export default function RollbackPanel() {
       <div className="flex items-center gap-2 mb-4">
         <RotateCcw size={20} className="text-warning" />
         <h2 className="text-xl font-semibold text-white">Rollback History</h2>
-        <div className="group relative ml-auto">
-          <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" />
-          <div className="invisible group-hover:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
+        <div className="relative ml-auto flex items-center">
+          <button type="button" className="peer focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none rounded-full" aria-label="More information">
+            <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" aria-hidden="true" />
+          </button>
+          <div role="tooltip" className="invisible peer-hover:visible peer-focus:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
             Complete safety net for all file operations. Every move, rename, or deletion can be undone. ADHD-friendly: eliminates anxiety about making mistakes.
           </div>
         </div>


### PR DESCRIPTION
🎨 **Palette: Make hover-only tooltips keyboard accessible**

### 💡 What
This PR updates the "Info" tooltips across the application to be keyboard accessible. Previously, these tooltips were only visible when hovering over the icon with a mouse. Now, they can be focused and revealed using the keyboard (e.g., via the `Tab` key).

### 🎯 Why
Tooltips that rely solely on `group-hover` are completely invisible to users navigating the site with a keyboard or screen reader. By making these interactive, we improve the overall accessibility and ensure all users can access the helpful context provided by these tooltips.

### 📸 Before/After
*(Verified visually via Playwright during pre-commit checks: Focus rings are now visible on the Info icons, and tooltips correctly appear when focused).*

### ♿ Accessibility
- Wrapped tooltip icons in `<button type="button">` to make them focusable.
- Added descriptive `aria-label`s to the buttons.
- Hid the decorative SVG icons from screen readers using `aria-hidden="true"`.
- Added `role="tooltip"` to the actual tooltip content.
- Ensured visual focus states use the application's standard focus rings.

---
*PR created automatically by Jules for task [1061854738406300721](https://jules.google.com/task/1061854738406300721) started by @thebearwithabite*