### PR TITLE
🛡️ Sentinel: Fix potential SQL Injection in dynamic ALTER TABLE queries

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,8 @@
 **Prevention:**
 1. Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
 2. Absolute paths always begin with a directory separator (`/` on Unix) or a drive letter (`C:\` on Windows), guaranteeing the command-line tool parses them as file paths rather than flags or options.
+
+## 2024-05-24 - Prevent SQL Injection in Dynamic ALTER TABLE
+**Vulnerability:** Constructing `ALTER TABLE` queries with dynamic column names using f-strings (e.g., `f"ALTER TABLE table ADD COLUMN {col_name} {col_type}"`) allows SQL injection if the column name is derived from untrusted input.
+**Learning:** Standard SQL parameterized queries (`?`) cannot be used to supply table or column names.
+**Prevention:** Always validate dynamic column names using Python's `str.isidentifier()` to ensure they contain only valid identifier characters before formatting them into the SQL string.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -231,6 +231,8 @@ class MetadataGenerator:
             migration_count = 0
             for col_name, col_type in gdrive_columns.items():
                 if col_name not in existing_columns:
+                    if not col_name.isidentifier():
+                        raise ValueError(f"Invalid column name: {col_name}")
                     conn.execute(f"ALTER TABLE file_metadata ADD COLUMN {col_name} {col_type}")
                     migration_count += 1
                     print(f"   ✅ Added column: {col_name}")


### PR DESCRIPTION
This PR addresses a potential SQL injection vulnerability in `metadata_generator.py` where column names were dynamically interpolated into `ALTER TABLE` statements without validation. Since SQLite does not support standard `?` parameterization for schema names, Python's built-in `str.isidentifier()` is used to ensure the column name strictly conforms to valid identifier characters, thereby preventing any malicious SQL syntax injection.

A journal entry reflecting this security learning is included in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16880557206740887135](https://jules.google.com/task/16880557206740887135) started by @thebearwithabite*