### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in dynamic column names

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Prevention:**
 1. Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
 2. Absolute paths always begin with a directory separator (`/` on Unix) or a drive letter (`C:\` on Windows), guaranteeing the command-line tool parses them as file paths rather than flags or options.
+## 2026-04-08 - Prevent SQL Injection via Dynamic Column Names
+**Vulnerability:** Constructing dynamic SQL queries with untrusted or unfiltered dictionary keys as column names leads to SQL injection, since placeholders only parameterize values.
+**Learning:** This codebase uses Python dictionaries mapped directly to SQLite schemas for convenience, bypassing schema-level protections and leaving column names exposed.
+**Prevention:** Always use PRAGMA table_info to generate an allowlist of valid columns and filter input dictionaries before query construction.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -467,9 +467,20 @@ class MetadataGenerator:
         
         try:
             with sqlite3.connect(self.db_path) as conn:
+                # Get valid columns from database schema to prevent SQL injection
+                cursor = conn.execute("PRAGMA table_info(file_metadata)")
+                valid_columns = {row[1] for row in cursor.fetchall()}
+
+                # Filter metadata to only include valid, safe column names
+                safe_metadata = {k: v for k, v in metadata.items()
+                               if k in valid_columns and str(k).isidentifier()}
+
+                if not safe_metadata:
+                    return False
+
                 # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                columns = list(safe_metadata.keys())
+                values = list(safe_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Constructing dynamic SQL queries with untrusted or unfiltered dictionary keys as column names leads to SQL injection, since `?` placeholders only parameterize values.
🎯 Impact: An attacker who manages to pass crafted dictionary keys into `save_file_metadata` can drop tables, alter schema, or gain unauthorized data access.
🔧 Fix: Used `PRAGMA table_info(file_metadata)` to fetch an allowlist of valid columns from the schema, and applied `.isidentifier()` to validate the keys before constructing the query.
✅ Verification: Ensure tests pass and the database interactions successfully fall back and fail safe when invalid columns are presented.

---
*PR created automatically by Jules for task [17926371033822138059](https://jules.google.com/task/17926371033822138059) started by @thebearwithabite*