### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in IdentityManager

### DIFF
--- a/frontend_v2/src/components/settings/IdentityManager.tsx
+++ b/frontend_v2/src/components/settings/IdentityManager.tsx
@@ -187,15 +187,19 @@ export default function IdentityManager() {
                                 <div className="flex gap-1">
                                     <button
                                         onClick={() => handleOpenDialog(identity)}
-                                        className="p-1.5 text-white/40 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+                                        className="p-1.5 text-white/40 hover:text-white hover:bg-white/10 rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"
+                                        aria-label={`Edit ${identity.name}`}
+                                        title={`Edit ${identity.name}`}
                                     >
-                                        <Edit2 size={14} />
+                                        <Edit2 size={14} aria-hidden="true" />
                                     </button>
                                     <button
                                         onClick={() => handleDelete(identity.id)}
-                                        className="p-1.5 text-white/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors"
+                                        className="p-1.5 text-white/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"
+                                        aria-label={`Delete ${identity.name}`}
+                                        title={`Delete ${identity.name}`}
                                     >
-                                        <Trash2 size={14} />
+                                        <Trash2 size={14} aria-hidden="true" />
                                     </button>
                                 </div>
                             </div>
@@ -239,9 +243,11 @@ export default function IdentityManager() {
                             </h2>
                             <button
                                 onClick={() => setIsDialogOpen(false)}
-                                className="p-2 text-white/40 hover:text-white transition-colors"
+                                className="p-2 text-white/40 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none"
+                                aria-label="Close dialog"
+                                title="Close dialog"
                             >
-                                <X size={20} />
+                                <X size={20} aria-hidden="true" />
                             </button>
                         </div>
 


### PR DESCRIPTION
💡 **What:** Added `aria-label`, `title`, and standard `focus-visible` ring styling to the Edit, Delete, and Close dialog buttons in the `IdentityManager` settings component. The inner SVG icons were also marked with `aria-hidden="true"`.

🎯 **Why:** These buttons contained only icons without visible text, making them completely inaccessible to screen reader users and confusing for keyboard navigators since they lacked focus rings or hover tooltips. 

♿ **Accessibility:** 
- Sighted users now get a helpful native tooltip on hover.
- Screen readers will correctly announce "Edit [Name]", "Delete [Name]", or "Close dialog" instead of reading generic button roles or attempting to parse the SVG content.
- Keyboard users receive a clear visual focus indicator when tabbing through the identity list.

---
*PR created automatically by Jules for task [16880382698081319679](https://jules.google.com/task/16880382698081319679) started by @thebearwithabite*