### PR TITLE
⚡ Bolt: Combine multiple SELECT COUNT aggregations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2025-05-27 - [Bulk SQLite Inserts and Connection Reuse for Tagging]
 **Learning:** Sequential `.execute` calls for `INSERT OR REPLACE` inside nested loops over large arrays (like tags) coupled with opening independent DB connections per method creates a severe N+1 problem. Benchmarks showed replacing it with a single shared connection and `executemany` arrays resulted in an ~2x speedup on typical batch tagging workloads.
 **Action:** Always batch related SQL records using `.executemany()` and pass an optional `db_connection` downstream to nested operations instead of establishing a new database connection every time.
+## 2026-04-09 - Combine Multiple SELECT Aggregations
+**Learning:** Running multiple `SELECT COUNT(*)` queries on the same table causes unnecessary database round-trips and full table scans.
+**Action:** Used conditional aggregation (`COUNT(CASE WHEN ... THEN 1 END)`) to combine multiple queries into a single SQLite query, reducing latency and resource usage.

--- a/learning_report.py
+++ b/learning_report.py
@@ -27,9 +27,14 @@ def generate_report():
             conn.row_factory = sqlite3.Row
             
             # 1. High Level Stats
-            total_events = conn.execute("SELECT COUNT(*) FROM learning_events").fetchone()[0]
-            verified_events = conn.execute("SELECT COUNT(*) FROM learning_events WHERE event_type IN ('user_correction', 'manual_move', 'preference_update', 'user_confirmed')").fetchone()[0]
-            observations = conn.execute("SELECT COUNT(*) FROM learning_events WHERE event_type = 'ai_observation'").fetchone()[0]
+            row = conn.execute("""
+                SELECT
+                    COUNT(*),
+                    COUNT(CASE WHEN event_type IN ('user_correction', 'manual_move', 'preference_update', 'user_confirmed') THEN 1 END),
+                    COUNT(CASE WHEN event_type = 'ai_observation' THEN 1 END)
+                FROM learning_events
+            """).fetchone()
+            total_events, verified_events, observations = row[0], row[1], row[2]
             
             print(f"📈 Knowledge Base Stats:")
             print(f"   Total Learning Events:  {total_events}")


### PR DESCRIPTION
* 💡 **What**: Replaced three sequential `SELECT COUNT(*)` queries on the `learning_events` table in `learning_report.py` with a single query using conditional aggregation (`COUNT(CASE WHEN ... THEN 1 END)`).
* 🎯 **Why**: Executing three separate count queries caused three consecutive database round-trips and full table scans. This is an N+1 query performance bottleneck.
* 📊 **Impact**: Reduces query latency by combining the aggregations into a single query and single table scan.
* 🔬 **Measurement**: Monitored query execution output using an in-memory test database, proving identical mathematical behavior while utilizing a single `execute` call instead of three.

---
*PR created automatically by Jules for task [10069473698369855225](https://jules.google.com/task/10069473698369855225) started by @thebearwithabite*