### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in save_file_metadata

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,8 @@
 **Prevention:**
 1. Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
 2. Absolute paths always begin with a directory separator (`/` on Unix) or a drive letter (`C:\` on Windows), guaranteeing the command-line tool parses them as file paths rather than flags or options.
+
+## 2024-05-31 - SQL Injection Vulnerability in Dynamic Column Names
+**Vulnerability:** The `save_file_metadata` method in `metadata_generator.py` dynamically generated `INSERT` column names directly from dictionary keys using an f-string, allowing SQL injection if keys were maliciously crafted.
+**Learning:** When constructing dynamic SQL queries (e.g., `INSERT` or `UPDATE` with dynamically generated column names), standard `?` parameterization does not protect column keys. You must use an explicit schema allowlist.
+**Prevention:** Use `PRAGMA table_info(table_name)` to fetch valid column names from the database schema and filter the dictionary keys against this allowlist before generating the dynamic SQL query.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -467,9 +467,19 @@ class MetadataGenerator:
         
         try:
             with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.cursor()
+                cursor.execute("PRAGMA table_info(file_metadata)")
+                valid_columns = {row[1] for row in cursor.fetchall()}
+
+                # Filter metadata to only include valid columns (prevents SQL injection)
+                filtered_metadata = {k: v for k, v in metadata.items() if k in valid_columns}
+
+                if not filtered_metadata:
+                    return False
+
                 # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                columns = list(filtered_metadata.keys())
+                values = list(filtered_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `save_file_metadata` method in `metadata_generator.py` dynamically generated SQL `INSERT` column names directly from dictionary keys using an f-string, allowing SQL injection if keys were maliciously crafted. Standard `?` parameterization does not protect column names or table names.
🎯 Impact: If a malicious dictionary key is passed to the function, it can be injected into the `INSERT` column names, leading to SQL injection which could leak data, cause errors, or modify database structure.
🔧 Fix: Used `PRAGMA table_info(file_metadata)` to fetch an explicit allowlist of valid column names directly from the database schema and filtered the dictionary keys against this allowlist before generating the dynamic SQL query.
✅ Verification: Created a test script to inject malicious dictionary keys into an SQLite database via the function and ensured the function filters out non-existent keys from the query securely without crashing or injecting standard SQL operations.

---
*PR created automatically by Jules for task [5457959408324638937](https://jules.google.com/task/5457959408324638937) started by @thebearwithabite*