### PR TITLE
🎨 Palette: Improve Sidebar Navigation Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-03-16 - Make hover-only actions keyboard accessible
 **Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
 **Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.
+## 2024-05-24 - Navigation Link Accessibility
+**Learning:** Custom navigation links built with React Router's `<Link>` or `<NavLink>` often lack semantic indication of the active page for screen readers, and rely heavily on visual cues. They also miss explicit focus rings unless styled manually.
+**Action:** Always add `aria-current="page"` to the active navigation item and explicitly define `focus-visible` styles on custom link wrappers to ensure keyboard and screen reader accessibility. Add `aria-hidden="true"` to decorative icons within links to prevent redundant announcements.

--- a/frontend_v2/src/components/layout/Sidebar.tsx
+++ b/frontend_v2/src/components/layout/Sidebar.tsx
@@ -24,15 +24,17 @@ export default function Sidebar() {
             <Link
               key={item.to}
               to={item.to}
+              aria-current={isActive ? 'page' : undefined}
               className={cn(
                 "flex items-center gap-3 px-4 py-3 rounded-lg transition-all duration-300",
+                "focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none",
                 isActive
                   ? "bg-primary text-white"
                   : "text-white/60 hover:bg-white/10 hover:text-white",
                 item.highlight && !isActive && "text-warning hover:text-warning"
               )}
             >
-              <Icon size={20} />
+              <Icon size={20} aria-hidden="true" />
               <span className="font-medium">{item.label}</span>
             </Link>
           )


### PR DESCRIPTION
💡 What: Added accessible focus rings, active page semantic indicators, and hid decorative icons on sidebar links.
   🎯 Why: To make the primary navigation keyboard-accessible and ensure screen readers announce the currently active page without redundant icon descriptions.
   📸 Before/After: Visual focus state is now distinct for keyboard users.
   ♿ Accessibility: Added `focus-visible` classes, `aria-current="page"`, and `aria-hidden="true"`.

---
*PR created automatically by Jules for task [4024212928535385819](https://jules.google.com/task/4024212928535385819) started by @thebearwithabite*