### PR TITLE
⚡ Bolt: Fix silently failing SQLite mmap_size configuration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2025-05-27 - [Bulk SQLite Inserts and Connection Reuse for Tagging]
 **Learning:** Sequential `.execute` calls for `INSERT OR REPLACE` inside nested loops over large arrays (like tags) coupled with opening independent DB connections per method creates a severe N+1 problem. Benchmarks showed replacing it with a single shared connection and `executemany` arrays resulted in an ~2x speedup on typical batch tagging workloads.
 **Action:** Always batch related SQL records using `.executemany()` and pass an optional `db_connection` downstream to nested operations instead of establishing a new database connection every time.
+## 2024-05-24 - SQLite Pragma Silent Failures
+**Learning:** In SQLite configurations, providing an invalid string to a PRAGMA command (like `PRAGMA mmap_size=XXXXXXXXX`) fails silently rather than throwing an error, which silently disables the performance feature (like memory-mapped I/O).
+**Action:** Always verify PRAGMA values are valid integer byte sizes (e.g., `268435456` for 256MB) and don't rely on exceptions to catch configuration syntax errors.

--- a/local_metadata_store.py
+++ b/local_metadata_store.py
@@ -162,7 +162,7 @@ class LocalMetadataStore:
             self._local.connection.execute("PRAGMA synchronous=NORMAL")  
             self._local.connection.execute("PRAGMA cache_size=10000")
             self._local.connection.execute("PRAGMA temp_store=MEMORY")
-            self._local.connection.execute("PRAGMA mmap_size=XXXXXXXXX")  # 256MB
+            self._local.connection.execute("PRAGMA mmap_size=268435456")  # 256MB
             
             # Enable foreign keys
             self._local.connection.execute("PRAGMA foreign_keys=ON")


### PR DESCRIPTION
💡 **What:** Replaces the invalid placeholder string `XXXXXXXXX` with the valid integer `268435456` for the SQLite `PRAGMA mmap_size` configuration in `local_metadata_store.py`. Also adds a journal entry to document the learning that SQLite pragmas fail silently on syntax errors.

🎯 **Why:** SQLite does not throw errors when invalid values are provided to PRAGMA commands; instead, it silently ignores them. This meant the intended performance feature (enabling memory-mapped I/O with a 256MB limit) was effectively disabled, leading to suboptimal read performance. 

📊 **Impact:** Enables SQLite memory-mapped I/O for the database connection, significantly speeding up database read operations by avoiding standard `read()` system calls and context switches, while keeping memory usage bounded to 256MB.

🔬 **Measurement:** Verify the configuration by running `PRAGMA mmap_size;` on an active SQLite connection instantiated by the store to ensure it correctly returns `268435456` instead of the default value.

---
*PR created automatically by Jules for task [10329768072084660331](https://jules.google.com/task/10329768072084660331) started by @thebearwithabite*