### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in metadata generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Prevention:**
 1. Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
 2. Absolute paths always begin with a directory separator (`/` on Unix) or a drive letter (`C:\` on Windows), guaranteeing the command-line tool parses them as file paths rather than flags or options.
+## 2024-05-24 - Fix SQL injection in metadata generation
+**Vulnerability:** SQL injection vulnerability via untrusted column names in dynamically generated INSERT/UPDATE query.
+**Learning:** Standard ? parameterization does not protect column keys; using `join` directly on untrusted keys allows arbitrary SQL strings to execute.
+**Prevention:** Always use an explicit schema allowlist via PRAGMA table_info to filter dictionary keys for dynamic SQL queries.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -463,14 +463,19 @@ class MetadataGenerator:
         
         return multimedia_data
     
+    @staticmethod
+    def _quote_identifier(name: str) -> str:
+        """Return a safely double-quoted SQLite identifier."""
+        return '"' + name.replace('"', '""') + '"'
+
     def save_file_metadata(self, metadata: Dict[str, Any]) -> bool:
         """Save file metadata to database safely, preventing SQL injection"""
         
         try:
             with sqlite3.connect(self.db_path) as conn:
                 # Validate column names to prevent SQL injection using a
-                # cached schema allowlist (refreshed once per connection).
-                if not hasattr(self, '_valid_columns_cache') or self._valid_columns_cache is None:
+                # cached schema allowlist (populated once, lazily).
+                if self._valid_columns_cache is None:
                     cursor = conn.execute("PRAGMA table_info(file_metadata)")
                     self._valid_columns_cache = {row[1] for row in cursor.fetchall()}
 
@@ -485,14 +490,13 @@ class MetadataGenerator:
                 columns = list(safe_metadata.keys())
                 values = list(safe_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
-                # Double-quote each column name and escape embedded quotes
-                column_names = ', '.join(f'"{c.replace(chr(34), chr(34)*2)}"' for c in columns)
+                column_names = ', '.join(self._quote_identifier(c) for c in columns)
                 
                 # Use UPSERT (ON CONFLICT DO UPDATE) instead of INSERT OR REPLACE
                 # so existing column values are preserved for columns not present
                 # in safe_metadata (INSERT OR REPLACE deletes and re-inserts the row).
                 update_clause = ', '.join(
-                    f'"{c.replace(chr(34), chr(34)*2)}" = excluded."{c.replace(chr(34), chr(34)*2)}"'
+                    f'{self._quote_identifier(c)} = excluded.{self._quote_identifier(c)}'
                     for c in columns
                 )
                 conn.execute(f"""

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -467,9 +467,19 @@ class MetadataGenerator:
         
         try:
             with sqlite3.connect(self.db_path) as conn:
+                # Fetch allowed columns from database schema
+                cursor = conn.execute("PRAGMA table_info(file_metadata)")
+                allowed_columns = {row[1] for row in cursor.fetchall()}
+
+                # Filter metadata to only include allowed columns
+                filtered_metadata = {k: v for k, v in metadata.items() if k in allowed_columns}
+
+                if not filtered_metadata:
+                    return False
+
                 # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                columns = list(filtered_metadata.keys())
+                values = list(filtered_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: In `metadata_generator.py`, the `save_file_metadata` method dynamically constructed SQL queries by interpolating dictionary keys into the `INSERT` statement. If an attacker controls a dictionary key during metadata insertion, they could execute arbitrary SQL statements.
🎯 **Impact**: Allowed arbitrary SQL execution or database schema alteration.
🔧 **Fix**: Added a schema validation mechanism using `PRAGMA table_info` to generate an explicit allowlist of valid columns. Incoming metadata dictionaries are filtered against this allowlist before building dynamic `INSERT` queries.
✅ **Verification**: Verified using a local test script that attempting to insert metadata with SQL injection payloads as column names will no longer succeed and are gracefully filtered out. Tests compile and run successfully. Added journal entry to `.jules/sentinel.md` outlining learning.

---
*PR created automatically by Jules for task [5654849873797559906](https://jules.google.com/task/5654849873797559906) started by @thebearwithabite*