### PR TITLE
🎨 Palette: Improve sidebar navigation accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-03-16 - Make hover-only actions keyboard accessible
 **Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
 **Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.
+## 2024-04-12 - Sidebar Navigation Accessibility
+**Learning:** React Router Links used for navigation items without `aria-current` lack semantic indication of the active page for screen readers, while visible text is sufficient without additional `aria-label`. Redundant `aria-hidden="true"` on decorative icons inside the link improves screen reader experience.
+**Action:** Always add `aria-current={isActive ? 'page' : undefined}` to active navigation links, apply explicit `focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none` classes for keyboard accessibility, and hide decorative inner icons with `aria-hidden="true"`.

--- a/frontend_v2/src/components/layout/Sidebar.tsx
+++ b/frontend_v2/src/components/layout/Sidebar.tsx
@@ -24,15 +24,17 @@ export default function Sidebar() {
             <Link
               key={item.to}
               to={item.to}
+              aria-current={isActive ? 'page' : undefined}
               className={cn(
                 "flex items-center gap-3 px-4 py-3 rounded-lg transition-all duration-300",
+                "focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none",
                 isActive
                   ? "bg-primary text-white"
                   : "text-white/60 hover:bg-white/10 hover:text-white",
                 item.highlight && !isActive && "text-warning hover:text-warning"
               )}
             >
-              <Icon size={20} />
+              <Icon size={20} aria-hidden="true" />
               <span className="font-medium">{item.label}</span>
             </Link>
           )


### PR DESCRIPTION
🎨 Palette: Improve sidebar navigation accessibility

- What: Added `aria-current="page"` to active links, hidden the inner icon from screen readers, and improved explicit focus styles for keyboard navigation in `Sidebar.tsx`.
- Why: To ensure screen reader users understand their current active page and keyboard users have a visible focus indicator without redundant screen reader announcements.
- Accessibility: Added semantic page active indication and enhanced keyboard focus visibility.

---
*PR created automatically by Jules for task [12893277590340128261](https://jules.google.com/task/12893277590340128261) started by @thebearwithabite*