### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in metadata store

### DIFF
--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -467,9 +467,19 @@ class MetadataGenerator:
         
         try:
             with sqlite3.connect(self.db_path) as conn:
+                # Get valid columns to prevent SQL injection
+                cursor = conn.execute("PRAGMA table_info(file_metadata)")
+                valid_columns = {row[1] for row in cursor.fetchall()}
+
+                # Filter metadata keys to only allow valid columns
+                safe_metadata = {k: v for k, v in metadata.items() if k in valid_columns}
+
+                if not safe_metadata:
+                    return False
+
                 # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                columns = list(safe_metadata.keys())
+                values = list(safe_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 


### PR DESCRIPTION
🛡️ **Severity:** CRITICAL
💡 **Vulnerability:** The dynamic `INSERT OR REPLACE` query in `metadata_generator.py` blindly joined incoming dictionary keys without validation, which allowed for potential SQL injection if the keys contained maliciously crafted column names or syntax.
🎯 **Impact:** An attacker could execute arbitrary SQL commands, potentially dropping tables, modifying schema, or compromising the integrity of the `file_metadata` table.
🔧 **Fix:** Replaced naive key joining with an explicit schema allowlist. The method now fetches valid columns using `PRAGMA table_info` and filters the incoming dictionary keys against these verified columns before proceeding with the query.
✅ **Verification:** A mock script testing both valid inserts and SQL injection payloads was successfully executed, confirming the vulnerability is mitigated and the table remains intact.

---
*PR created automatically by Jules for task [4181258138857006877](https://jules.google.com/task/4181258138857006877) started by @thebearwithabite*