### PR TITLE
🎨 Palette: Make hover-only actions keyboard accessible

### DIFF
--- a/frontend_v2/src/components/veo/AssetLibrary.tsx
+++ b/frontend_v2/src/components/veo/AssetLibrary.tsx
@@ -237,7 +237,8 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
             <button
                 onClick={onRemove}
                 type="button"
-                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100">
+                aria-label="Remove asset"
+                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100 focus-visible:opacity-100 focus-visible:scale-100 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none">
                 <XMarkIcon className="w-3 h-3" />
             </button>
 
@@ -261,11 +262,11 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
                     </label>
                 )}
                 {asset.image && (
-                    <label className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-md p-2 rounded-full cursor-pointer hover:bg-indigo-600 border border-white/10 opacity-0 group-hover:opacity-100 transition-all scale-75 group-hover:scale-100">
+                    <label className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-md p-2 rounded-full cursor-pointer hover:bg-indigo-600 border border-white/10 opacity-0 group-hover:opacity-100 transition-all scale-75 group-hover:scale-100 focus-within:opacity-100 focus-within:scale-100 focus-within:ring-2 focus-within:ring-white/50 focus-within:outline-none">
                         <UploadCloudIcon className="w-3 h-3 text-white" />
                         <input
                             type="file"
-                            className="hidden"
+                            className="sr-only"
                             onChange={onUpload}
                             accept="image/png, image/jpeg, image/webp"
                         />

--- a/frontend_v2/src/components/veo/ShotCard.tsx
+++ b/frontend_v2/src/components/veo/ShotCard.tsx
@@ -95,14 +95,14 @@ const ShotCard: React.FC<ShotCardProps> = ({
                         <pre className="text-indigo-400/80 leading-relaxed">
                             <code>{shot.veoJson ? JSON.stringify(shot.veoJson, null, 2) : '// Awaiting Director Breakdown...'}</code>
                         </pre>
-                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-all translate-y-2 group-hover:translate-y-0">
+                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-all translate-y-2 group-hover:translate-y-0 focus-within:translate-y-0">
                             <button
                                 onClick={() => {
                                     navigator.clipboard.writeText(JSON.stringify(shot.veoJson, null, 2));
                                     setCopyButtonText('Copied!');
                                     setTimeout(() => setCopyButtonText('Copy JSON'), 2000);
                                 }}
-                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all"
+                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none"
                             >
                                 {copyButtonText}
                             </button>


### PR DESCRIPTION
💡 **What:** Improved keyboard accessibility for elements that are only visible on hover by adding focus-related states (`focus-visible`, `focus-within`) and necessary ARIA labels.

🎯 **Why:** To ensure keyboard-only users can access these secondary actions without needing a mouse hover, preventing them from missing or being unable to interact with key functionalities like "Copy JSON" or removing assets.

📸 **Before/After:** No visual change for mouse users, but keyboard tab traversal now highlights and reveals these buttons.

♿ **Accessibility:** Added `aria-label` to the remove button, used `sr-only` for the file input to make it focusable by screen readers instead of `hidden`, and fixed tab-navigation visibility using `focus-visible` and `focus-within`.

---
*PR created automatically by Jules for task [5947334724413290427](https://jules.google.com/task/5947334724413290427) started by @thebearwithabite*