### PR TITLE
⚡ Bolt: Use executemany for batch SQLite inserts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2025-05-27 - [Bulk SQLite Inserts and Connection Reuse for Tagging]
 **Learning:** Sequential `.execute` calls for `INSERT OR REPLACE` inside nested loops over large arrays (like tags) coupled with opening independent DB connections per method creates a severe N+1 problem. Benchmarks showed replacing it with a single shared connection and `executemany` arrays resulted in an ~2x speedup on typical batch tagging workloads.
 **Action:** Always batch related SQL records using `.executemany()` and pass an optional `db_connection` downstream to nested operations instead of establishing a new database connection every time.
+## 2024-04-14 - Batch SQLite Inserts for Interactive Processor
+**Learning:** Found an N+1 SQLite insertion loop inside the interactive batch processor when saving user decisions. Writing multiple single rows sequentially is significantly slower than batching them due to transaction overhead.
+**Action:** Used `executemany` with a generator/list comprehension to insert all `FilePreview` decisions in a batch to eliminate the bottleneck.

--- a/interactive_batch_processor.py
+++ b/interactive_batch_processor.py
@@ -1358,20 +1358,25 @@ class InteractiveBatchProcessor:
         """Record user decision for learning"""
         try:
             with sqlite3.connect(self.batch_db_path) as conn:
-                for fp in group.file_previews:
-                    conn.execute("""
-                        INSERT INTO user_feedback
-                        (feedback_id, session_id, file_path, predicted_action, user_action, feedback_time, comments)
-                        VALUES (?, ?, ?, ?, ?, ?, ?)
-                    """, (
-                        hashlib.md5(f"{session_id}_{fp.file_path}_{datetime.now().isoformat()}".encode()).hexdigest()[:12],
-                        session_id,
-                        fp.file_path,
-                        fp.predicted_category,
-                        user_decision.get("action", "unknown"),
-                        datetime.now().isoformat(),
-                        json.dumps(user_decision)
-                    ))
+                current_time = datetime.now().isoformat()
+                user_action = user_decision.get("action", "unknown")
+                comments = json.dumps(user_decision)
+
+                rows = [(
+                    hashlib.md5(f"{session_id}_{fp.file_path}_{current_time}".encode()).hexdigest()[:12],
+                    session_id,
+                    fp.file_path,
+                    fp.predicted_category,
+                    user_action,
+                    current_time,
+                    comments
+                ) for fp in group.file_previews]
+
+                conn.executemany("""
+                    INSERT INTO user_feedback
+                    (feedback_id, session_id, file_path, predicted_action, user_action, feedback_time, comments)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                """, rows)
                 conn.commit()
         except Exception as e:
             self.logger.error(f"Error recording user decision: {e}")


### PR DESCRIPTION
💡 What: Replaced looped `conn.execute` statements with `conn.executemany` in `_record_user_decision`.
🎯 Why: To fix an N+1 database insertion bottleneck where every file preview was inserted sequentially, incurring multiple transaction overheads.
📊 Impact: Significantly faster execution when users make bulk decisions on large file batches.
🔬 Measurement: Verified with unit tests; can be further tested by processing a batch with many files and measuring execution time of `_record_user_decision`.

---
*PR created automatically by Jules for task [9025905341258143943](https://jules.google.com/task/9025905341258143943) started by @thebearwithabite*