### PR TITLE
🎨 Palette: Add ARIA labels and focus states to Veo form icon buttons

### DIFF
--- a/frontend_v2/src/components/veo/VeoProjectForm.tsx
+++ b/frontend_v2/src/components/veo/VeoProjectForm.tsx
@@ -103,8 +103,8 @@ const VeoProjectForm: React.FC<VeoProjectFormProps> = ({
                     <div className="flex justify-between items-center mb-8 relative z-10">
                         <p className="text-[11px] text-white/40 font-bold uppercase tracking-widest leading-none">Draft your scene beats or upload a screenplay</p>
                         <div className="flex gap-2">
-                            <button type="button" onClick={() => scriptFileInputRef.current?.click()} className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileUploadIcon className="w-4 h-4" /></button>
-                            <button type="button" className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all"><FileAudioIcon className="w-4 h-4" /></button>
+                            <button type="button" aria-label="Upload script file" onClick={() => scriptFileInputRef.current?.click()} className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"><FileUploadIcon aria-hidden="true" className="w-4 h-4" /></button>
+                            <button type="button" aria-label="Record audio script" className="p-3 bg-black/40 border border-white/5 rounded-xl hover:bg-white/10 text-white/40 hover:text-white transition-all focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"><FileAudioIcon aria-hidden="true" className="w-4 h-4" /></button>
                         </div>
                     </div>
 


### PR DESCRIPTION
💡 **What:** Added `aria-label`s and `focus-visible` styles to the script upload and audio record icon-only buttons in the VeoProjectForm. Also added `aria-hidden="true"` to the inner SVGs.

🎯 **Why:** To improve accessibility for screen readers (which previously had no way to identify these icon-only buttons) and keyboard navigation (which lacked clear focus indicators for these elements).

📸 **Before/After:** The visual appearance remains the same for mouse users. Keyboard users will now see a clear focus ring, and screen reader users will hear "Upload script file" or "Record audio script".

♿ **Accessibility:** This directly addresses WCAG requirements for icon-only buttons (providing text alternatives) and keyboard accessibility (providing visible focus indicators). Also prevents duplicate announcements by hiding decorative SVGs from the accessibility tree.

---
*PR created automatically by Jules for task [13237194581843107783](https://jules.google.com/task/13237194581843107783) started by @thebearwithabite*