### PR TITLE
⚡ Bolt: Optimize SQLite inserts in batch processor

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2025-05-27 - [Bulk SQLite Inserts and Connection Reuse for Tagging]
 **Learning:** Sequential `.execute` calls for `INSERT OR REPLACE` inside nested loops over large arrays (like tags) coupled with opening independent DB connections per method creates a severe N+1 problem. Benchmarks showed replacing it with a single shared connection and `executemany` arrays resulted in an ~2x speedup on typical batch tagging workloads.
 **Action:** Always batch related SQL records using `.executemany()` and pass an optional `db_connection` downstream to nested operations instead of establishing a new database connection every time.
+## 2024-05-30 - Optimize batch processing db inserts
+**Learning:** Performing `conn.execute()` sequentially in a loop against a SQLite database creates N+1 database roundtrips, increasing I/O latency on disk-backed operations.
+**Action:** Replace `execute()` with `executemany()` to send multiple rows in a single operation, batching I/O and vastly improving write speeds.

--- a/interactive_batch_processor.py
+++ b/interactive_batch_processor.py
@@ -1358,20 +1358,28 @@ class InteractiveBatchProcessor:
         """Record user decision for learning"""
         try:
             with sqlite3.connect(self.batch_db_path) as conn:
+                records = []
+                now_iso = datetime.now().isoformat()
+                action = user_decision.get("action", "unknown")
+                comments = json.dumps(user_decision)
+
                 for fp in group.file_previews:
-                    conn.execute("""
-                        INSERT INTO user_feedback
-                        (feedback_id, session_id, file_path, predicted_action, user_action, feedback_time, comments)
-                        VALUES (?, ?, ?, ?, ?, ?, ?)
-                    """, (
-                        hashlib.md5(f"{session_id}_{fp.file_path}_{datetime.now().isoformat()}".encode()).hexdigest()[:12],
+                    feedback_id = hashlib.md5(f"{session_id}_{fp.file_path}_{now_iso}".encode()).hexdigest()[:12]
+                    records.append((
+                        feedback_id,
                         session_id,
                         fp.file_path,
                         fp.predicted_category,
-                        user_decision.get("action", "unknown"),
-                        datetime.now().isoformat(),
-                        json.dumps(user_decision)
+                        action,
+                        now_iso,
+                        comments
                     ))
+
+                conn.executemany("""
+                    INSERT INTO user_feedback
+                    (feedback_id, session_id, file_path, predicted_action, user_action, feedback_time, comments)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                """, records)
                 conn.commit()
         except Exception as e:
             self.logger.error(f"Error recording user decision: {e}")


### PR DESCRIPTION
💡 What: Replaced looped `conn.execute()` calls with `conn.executemany()` in `interactive_batch_processor.py`'s `_record_user_decision` method.
🎯 Why: Looping over `execute()` for database inserts causes an N+1 database round-trip bottleneck. `executemany()` batches the inserts into a single operation, reducing I/O overhead.
📊 Impact: Reduces database latency and speeds up batch insertions when processing large file groups.
🔬 Measurement: Verified through isolated temporary mock script timing the two insertion approaches using a disk-backed SQLite database.

---
*PR created automatically by Jules for task [306870855384834477](https://jules.google.com/task/306870855384834477) started by @thebearwithabite*