### PR TITLE
⚡ Bolt: [performance improvement] Optimizing SQLite insertions by replacing execute with executemany in _record_user_decision

### DIFF
--- a/interactive_batch_processor.py
+++ b/interactive_batch_processor.py
@@ -1358,20 +1358,28 @@ class InteractiveBatchProcessor:
         """Record user decision for learning"""
         try:
             with sqlite3.connect(self.batch_db_path) as conn:
-                for fp in group.file_previews:
-                    conn.execute("""
-                        INSERT INTO user_feedback
-                        (feedback_id, session_id, file_path, predicted_action, user_action, feedback_time, comments)
-                        VALUES (?, ?, ?, ?, ?, ?, ?)
-                    """, (
-                        hashlib.md5(f"{session_id}_{fp.file_path}_{datetime.now().isoformat()}".encode()).hexdigest()[:12],
+                now_iso = datetime.now().isoformat()
+                action = user_decision.get("action", "unknown")
+                comments = json.dumps(user_decision)
+
+                rows = [
+                    (
+                        hashlib.md5(f"{session_id}_{fp.file_path}_{now_iso}".encode()).hexdigest()[:12],
                         session_id,
                         fp.file_path,
                         fp.predicted_category,
-                        user_decision.get("action", "unknown"),
-                        datetime.now().isoformat(),
-                        json.dumps(user_decision)
-                    ))
+                        action,
+                        now_iso,
+                        comments
+                    )
+                    for fp in group.file_previews
+                ]
+
+                conn.executemany("""
+                    INSERT INTO user_feedback
+                    (feedback_id, session_id, file_path, predicted_action, user_action, feedback_time, comments)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                """, rows)
                 conn.commit()
         except Exception as e:
             self.logger.error(f"Error recording user decision: {e}")


### PR DESCRIPTION
### 💡 What
Replaced a loop of repeated `conn.execute()` queries with a single `conn.executemany()` operation inside `_record_user_decision` in `interactive_batch_processor.py`. Also hoisted invariant calculations (e.g., `datetime.now().isoformat()`, `json.dumps`) out of the iteration loop.

### 🎯 Why
Executing sequential `INSERT` statements within a Python `for` loop over large arrays introduces significant N+1 performance overhead. Consolidating into a single batched `executemany()` operation drastically reduces latency and minimizes roundtrips across the database boundary.

### 📊 Impact
Eliminates O(N) repetitive SQL parses and significantly decreases batch processing time and CPU load when evaluating decisions on heavily populated file previews arrays.

### 🔬 Measurement
Tests via unit testing execution and a mock script execution verifying identical output properties (i.e., table entries persist successfully per `session_id`).

---
*PR created automatically by Jules for task [12303098320918172003](https://jules.google.com/task/12303098320918172003) started by @thebearwithabite*