### PR TITLE
🎨 Palette: Make hover-only remove button keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,11 @@
 ## 2024-03-16 - Make hover-only actions keyboard accessible
 **Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
 **Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.
+
+## 2024-04-17 - Extend keyboard accessibility to all hover-revealed elements
+**Learning:** In addition to lists, interactive elements revealed only on hover within cards and library components (like copy buttons and upload actions) must also receive keyboard accessibility features. Otherwise, they remain invisible and unusable for screen reader and keyboard-only users.
+**Action:** Apply `focus-visible:opacity-100`, `focus-visible:scale-100`, `focus-visible:translate-y-0`, `focus-visible:ring-2`, and `focus-visible:outline-none` (matching existing hover transitions) to all hidden actionable elements. Also add `aria-label`s to icon-only buttons.
+
+## 2024-04-17 - Keyboard accessible liquid glass buttons
+**Learning:** Visually hidden icon-only buttons (using `opacity-0 scale-90 group-hover:opacity-100 group-hover:scale-100`) are inaccessible to keyboard users and lack semantic meaning for screen readers.
+**Action:** Pair hover visibility classes with explicit `focus-visible:opacity-100 focus-visible:scale-100` and standard focus rings (`focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none`) alongside an `aria-label` to be fully keyboard accessible.

--- a/frontend_v2/src/components/veo/AssetLibrary.tsx
+++ b/frontend_v2/src/components/veo/AssetLibrary.tsx
@@ -237,8 +237,9 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
             <button
                 onClick={onRemove}
                 type="button"
-                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 transition-all border border-white/10 scale-90 group-hover:scale-100">
-                <XMarkIcon className="w-3 h-3" />
+                aria-label="Remove asset"
+                className="absolute top-2 right-2 z-20 bg-black/60 backdrop-blur-md text-white/60 hover:text-white rounded-full p-1.5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:scale-100 focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none transition-all border border-white/10 scale-90 group-hover:scale-100">
+                <XMarkIcon className="w-3 h-3" aria-hidden="true" />
             </button>
 
             <div className="aspect-[4/3] bg-black/40 relative overflow-hidden">


### PR DESCRIPTION
💡 What: Applied `focus-visible` utility classes and an `aria-label` to the hidden icon-only "Remove asset" button in the Veo Studio Asset Library.

🎯 Why: The button was hidden behind an `opacity-0` class and only visible on `group-hover`. This made it completely invisible and inaccessible to users navigating via keyboard (Tab). Adding these utilities ensures it becomes visible and styled consistently when focused.

📸 Before/After: Before, tabbing through the UI would skip the button's visibility (it would receive focus but remain `opacity-0`). After, the button instantly appears (`opacity-100 scale-100`) with a clear focus ring (`ring-2`) when navigated to via the keyboard.

♿ Accessibility: Added `aria-label="Remove asset"` and `aria-hidden="true"` to the internal SVG to provide clear, semantic context to screen readers, while ensuring keyboard-only users can visibly see and interact with the action.

---
*PR created automatically by Jules for task [1627171732453737596](https://jules.google.com/task/1627171732453737596) started by @thebearwithabite*