### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in metadata storage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,13 @@
 **Prevention:**
 1. Always convert `pathlib.Path` objects to absolute strings using `str(path.absolute())` before passing them as arguments to `subprocess.run`.
 2. Absolute paths always begin with a directory separator (`/` on Unix) or a drive letter (`C:\` on Windows), guaranteeing the command-line tool parses them as file paths rather than flags or options.
+## 2024-05-30 - SQL Injection via Dictionary Keys in Dynamic Queries
+
+**Vulnerability:** The `save_file_metadata` function in `metadata_generator.py` accepted an untrusted dictionary of metadata and dynamically constructed an `INSERT` statement using the dictionary's keys as column names (`column_names = ', '.join(columns)`). This allowed SQL injection if an attacker supplied a malformed key (e.g., `invalid_column) VALUES (?); DROP TABLE files; --`).
+
+**Learning:** While parameterization (`?`) protects against SQL injection in values, it does not protect against injection in table or column names. When dynamically building queries where column names are derived from user input or external dictionaries, the keys must be strictly validated against an explicit schema allowlist.
+
+**Prevention:**
+1. Never use untrusted input directly as column names or table names in SQL queries.
+2. Fetch valid columns dynamically using `PRAGMA table_info(table_name)` in SQLite (or hardcode an allowlist).
+3. Pre-filter dictionaries to only include keys that match the explicitly validated schema allowlist before building dynamic queries.

--- a/metadata_generator.py
+++ b/metadata_generator.py
@@ -463,13 +463,24 @@ class MetadataGenerator:
         return multimedia_data
     
     def save_file_metadata(self, metadata: Dict[str, Any]) -> bool:
-        """Save file metadata to database"""
+        """Save file metadata to database safely, preventing SQL injection"""
         
         try:
             with sqlite3.connect(self.db_path) as conn:
+                # Validate column names to prevent SQL injection
+                cursor = conn.execute("PRAGMA table_info(file_metadata)")
+                valid_columns = {row[1] for row in cursor.fetchall()}
+
+                # Filter metadata to only include valid columns
+                safe_metadata = {k: v for k, v in metadata.items() if k in valid_columns}
+
+                if not safe_metadata:
+                    print("Warning: No valid metadata fields to save")
+                    return False
+
                 # Convert to database format
-                columns = list(metadata.keys())
-                values = list(metadata.values())
+                columns = list(safe_metadata.keys())
+                values = list(safe_metadata.values())
                 placeholders = ', '.join(['?' for _ in values])
                 column_names = ', '.join(columns)
                 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `save_file_metadata` function in `metadata_generator.py` constructed an `INSERT` statement by directly joining keys from an untrusted dictionary. While values were parameterized, column names were not, allowing SQL injection if malformed keys were provided.
🎯 Impact: An attacker could execute arbitrary SQL commands, potentially exfiltrating sensitive data, modifying the database schema, or destroying records.
🔧 Fix: Added a dynamic schema validation step that queries `PRAGMA table_info(file_metadata)` to get a list of valid columns. The input metadata dictionary is now pre-filtered against this allowlist before building the SQL query.
✅ Verification: Run the provided unit tests to ensure that the function still accurately saves valid metadata, while ignoring any non-existent columns.

---
*PR created automatically by Jules for task [15719558972616725239](https://jules.google.com/task/15719558972616725239) started by @thebearwithabite*