### PR TITLE
🎨 Palette: Improve accessibility of navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-03-16 - Make hover-only actions keyboard accessible
 **Learning:** Actions hidden behind `opacity-0` and revealed with `group-hover:opacity-100` are completely inaccessible to keyboard-only users navigating via Tab. This is a common pattern for "secondary" actions like undo/delete buttons in lists.
 **Action:** When using `opacity-0 group-hover:opacity-100` to hide secondary actions, always pair it with `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to ensure the action becomes visible and clearly highlighted when focused via keyboard navigation.
+## 2025-02-14 - Navigation Link Accessibility Pattern
+**Learning:** Custom React Router `<Link>` components in the app lack `aria-current="page"` to semantically indicate the active page, explicit `focus-visible` styles for keyboard navigation, and `aria-hidden="true"` on decorative inner icons, leading to redundant screen reader announcements and poor keyboard navigation experience.
+**Action:** When implementing custom navigation links, always add `aria-current={isActive ? 'page' : undefined}`, explicit focus styles (e.g., `focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none`), and hide decorative inner icons using `aria-hidden="true"`.

--- a/frontend_v2/src/components/layout/Sidebar.tsx
+++ b/frontend_v2/src/components/layout/Sidebar.tsx
@@ -24,15 +24,16 @@ export default function Sidebar() {
             <Link
               key={item.to}
               to={item.to}
+              aria-current={isActive ? 'page' : undefined}
               className={cn(
-                "flex items-center gap-3 px-4 py-3 rounded-lg transition-all duration-300",
+                "flex items-center gap-3 px-4 py-3 rounded-lg transition-all duration-300 focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none",
                 isActive
                   ? "bg-primary text-white"
                   : "text-white/60 hover:bg-white/10 hover:text-white",
                 item.highlight && !isActive && "text-warning hover:text-warning"
               )}
             >
-              <Icon size={20} />
+              <Icon size={20} aria-hidden="true" />
               <span className="font-medium">{item.label}</span>
             </Link>
           )


### PR DESCRIPTION
💡 What: Added `aria-current="page"` to the active navigation link, added explicit `focus-visible` classes for keyboard focus styling, and added `aria-hidden="true"` to the decorative inner icons in the Sidebar navigation.
🎯 Why: To semantically indicate the active page for screen readers, provide clear visual feedback for keyboard users during navigation, and prevent redundant screen reader announcements for decorative icons.
📸 Before/After: Visual focus states now show a clear primary-colored ring around the active/focused navigation link.
♿ Accessibility: Improved semantic correctness with `aria-current`, enhanced keyboard navigability with `focus-visible` states, and reduced screen reader noise by hiding decorative icons.

---
*PR created automatically by Jules for task [6677944390245345435](https://jules.google.com/task/6677944390245345435) started by @thebearwithabite*