### PR TITLE
🎨 Palette: Make Triage Skip button accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-23 - Accessible Icon-Only Buttons in Custom Design System
 **Learning:** In the liquid glass design system, visually hidden icon-only buttons (like remove buttons on hover) require specific focus-visible utility classes (`focus-visible:opacity-100 focus-visible:scale-100`) combined with standard focus rings to remain keyboard accessible.
 **Action:** Always pair `group-hover:opacity-100` on hidden icon buttons with explicit `focus-visible:opacity-100` and standard focus ring utilities (`focus-visible:ring-2 focus-visible:ring-background/50 focus-visible:outline-none`) to ensure keyboard users can discover and interact with them. Apply `aria-hidden="true"` to the inner SVGs and `aria-label` to the buttons.
+## 2024-04-23 - Accessible Skip Button in Triage
+
+**Learning:** Icon-only buttons used for secondary actions (like skipping a file) are easily overlooked for accessibility, and default browser focus styles are often invisible on custom design system components lacking explicit `focus-visible` styling. Screen readers need a clear, action-oriented `aria-label`, and the inner SVG must be explicitly hidden (`aria-hidden="true"`) to prevent redundancy.
+**Action:** When adding or auditing icon-only utility buttons, consistently enforce the triad: `aria-label` on the button, `aria-hidden="true"` on the SVG, and explicit `focus-visible:ring-2 focus-visible:outline-none` styles for keyboard navigability.

--- a/frontend_v2/src/pages/Triage.tsx
+++ b/frontend_v2/src/pages/Triage.tsx
@@ -440,10 +440,11 @@ export default function Triage() {
                     </button>
                     <button
                       onClick={() => handleSkip(file)}
-                      className="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-xl transition-colors"
+                      className="px-4 py-2 bg-white/10 hover:bg-white/20 rounded-xl transition-colors focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
                       title="Skip this file"
+                      aria-label="Skip this file"
                     >
-                      <XCircle size={18} className="text-white/60" />
+                      <XCircle size={18} className="text-white/60" aria-hidden="true" />
                     </button>
                   </div>
                 </div>


### PR DESCRIPTION
- 💡 What: Added ARIA label, keyboard focus states, and aria-hidden on the icon for the "Skip" button in Triage view.
- 🎯 Why: Icon-only buttons must have an accessible name for screen reader users and explicit focus indicators for keyboard users since default browser outlines are often invisible or stripped in custom design systems.
- 📸 Before/After: Visual focus state added (see Playwright verification).
- ♿ Accessibility: Fixes a WCAG 2.1.1 Keyboard and 4.1.2 Name, Role, Value failure.

---
*PR created automatically by Jules for task [6647902296896720411](https://jules.google.com/task/6647902296896720411) started by @thebearwithabite*