### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/frontend_v2/src/components/ForensicVault.tsx
+++ b/frontend_v2/src/components/ForensicVault.tsx
@@ -131,6 +131,7 @@ export default function ForensicVault() {
                         onClick={loadFiles}
                         className="p-2.5 bg-white/5 border border-white/10 rounded-xl text-white/60 hover:text-white hover:bg-white/10 transition-all"
                         title="Refresh Manifest"
+                        aria-label="Refresh Manifest"
                     >
                         <RefreshCw size={18} className={cn(loading && "animate-spin")} />
                     </button>

--- a/frontend_v2/src/components/organize/ClassificationPreview.tsx
+++ b/frontend_v2/src/components/organize/ClassificationPreview.tsx
@@ -193,6 +193,7 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         <button
           onClick={handleSkip}
           className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white"
+          aria-label="Skip"
         >
           <X size={20} />
         </button>

--- a/frontend_v2/src/components/triage/MediaPreview.tsx
+++ b/frontend_v2/src/components/triage/MediaPreview.tsx
@@ -126,6 +126,7 @@ export default function MediaPreview({ filePath, fileType }: MediaPreviewProps) 
                 <button
                     onClick={togglePlay}
                     className="p-2 hover:bg-white/10 rounded-full transition-colors text-white"
+                    aria-label={isPlaying ? "Pause" : "Play"}
                 >
                     {isPlaying ? <Pause size={20} /> : <Play size={20} />}
                 </button>
@@ -140,6 +141,7 @@ export default function MediaPreview({ filePath, fileType }: MediaPreviewProps) 
                 <button
                     onClick={toggleMute}
                     className="p-2 hover:bg-white/10 rounded-full transition-colors text-white/70"
+                    aria-label={isMuted ? "Unmute" : "Mute"}
                 >
                     {isMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
                 </button>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to icon-only buttons in `MediaPreview.tsx`, `ForensicVault.tsx`, and `ClassificationPreview.tsx`.
🎯 Why: To improve keyboard navigation and screen reader support, ensuring interactive elements have an accessible name.
📸 Before/After: Added `aria-label` prop to button JSX.
♿ Accessibility: The play/pause, mute/unmute, refresh, and skip buttons are now properly announced by screen readers.

---
*PR created automatically by Jules for task [15948905827387410763](https://jules.google.com/task/15948905827387410763) started by @thebearwithabite*