### PR TITLE
🎨 Palette: Make Asset Library upload inputs keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,6 @@
 ## 2024-05-02 - Ensure Focus Visibility in Error Banners
 **Learning:** Error states and persistent disconnected banners (like `ConnectionStatus.tsx`) often utilize standalone or ad-hoc button components that bypass standard design system components. These elements are easily missed during standard accessibility checks but are critically important during degraded system states when users rely heavily on keyboard navigation.
 **Action:** Whenever introducing or modifying non-standard error banners, always manually verify and inject explicit `focus-visible` styles (e.g., `focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none`) to interactive elements.
+## 2024-05-24 - Accessible File Upload Wrappers
+**Learning:** When interactive elements are visually hidden by `opacity-0` on a parent wrapper element, applying `focus-visible` to the child is insufficient for accessibility. Apply `focus-within:opacity-100` to the wrapper element so the content is revealed when keyboard focus enters. Additionally, for file inputs wrapped in custom labels, use `className="sr-only"` instead of `hidden` to ensure the input remains in the accessibility tree and is focusable.
+**Action:** Replace `hidden` with `sr-only` on custom file inputs, and use `focus-within` utilities on their label wrappers to visually indicate focus.

--- a/frontend_v2/src/components/veo/AssetLibrary.tsx
+++ b/frontend_v2/src/components/veo/AssetLibrary.tsx
@@ -250,23 +250,23 @@ const AssetCard = ({ asset, onRemove, onUpload }: AssetCardProps) => {
                         className="w-full h-full object-cover opacity-60 group-hover:opacity-100 group-hover:scale-105 transition-all duration-700"
                     />
                 ) : (
-                    <label className="absolute inset-0 flex flex-col items-center justify-center cursor-pointer hover:bg-white/5 transition-all group/upload">
+                    <label className="absolute inset-0 flex flex-col items-center justify-center cursor-pointer hover:bg-white/5 transition-all group/upload focus-within:bg-white/5 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500 focus-within:outline-none">
                         <UploadCloudIcon className="w-8 h-8 text-white/10 mb-2 group-hover/upload:text-indigo-400 group-hover/upload:scale-110 transition-all duration-300" />
                         <span className="text-[9px] font-black uppercase text-white/20 tracking-widest group-hover/upload:text-indigo-400">Upload Still</span>
                         <input
                             type="file"
-                            className="hidden"
+                            className="sr-only"
                             onChange={onUpload}
                             accept="image/png, image/jpeg, image/webp"
                         />
                     </label>
                 )}
                 {asset.image && (
-                    <label className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-md p-2 rounded-full cursor-pointer hover:bg-indigo-600 border border-white/10 opacity-0 group-hover:opacity-100 transition-all scale-75 group-hover:scale-100">
+                    <label className="absolute bottom-2 right-2 bg-black/60 backdrop-blur-md p-2 rounded-full cursor-pointer hover:bg-indigo-600 border border-white/10 opacity-0 group-hover:opacity-100 focus-within:opacity-100 focus-within:scale-100 focus-within:ring-2 focus-within:ring-white/50 focus-within:outline-none transition-all scale-75 group-hover:scale-100">
                         <UploadCloudIcon className="w-3 h-3 text-white" />
                         <input
                             type="file"
-                            className="hidden"
+                            className="sr-only"
                             onChange={onUpload}
                             accept="image/png, image/jpeg, image/webp"
                         />


### PR DESCRIPTION
💡 What: Replaced `hidden` with `sr-only` on file input elements in `AssetLibrary.tsx` and added `focus-within` styling to their parent `<label>` wrappers.
🎯 Why: Elements with `display: none` (like Tailwind's `hidden`) are removed from the accessibility tree, making them impossible to focus via keyboard. This locked keyboard-only users out of uploading assets.
📸 Before/After: Visuals remain unchanged for mouse users. For keyboard users, tabbing to the asset cards now properly focuses the upload inputs and visually highlights their wrappers.
♿ Accessibility: Ensures critical file upload functionality is available to keyboard-only and screen reader users by restoring the inputs to the DOM accessibility tree and providing clear visual focus indicators.

---
*PR created automatically by Jules for task [8667231162207887348](https://jules.google.com/task/8667231162207887348) started by @thebearwithabite*