### PR TITLE
🎨 Palette: Improve accessibility of icon buttons in Media and Sidecar viewers

### DIFF
--- a/frontend_v2/src/components/triage/JsonSidecarViewer.tsx
+++ b/frontend_v2/src/components/triage/JsonSidecarViewer.tsx
@@ -43,14 +43,16 @@ export default function JsonSidecarViewer({ filePath }: JsonSidecarViewerProps) 
         <div className="mt-4 border border-white/10 rounded-xl overflow-hidden bg-white/5">
             <button
                 onClick={() => setIsOpen(!isOpen)}
-                className="w-full px-4 py-3 flex items-center justify-between hover:bg-white/5 transition-colors"
+                aria-expanded={isOpen}
+                aria-label="Toggle Sidecar Metadata"
+                className="w-full px-4 py-3 flex items-center justify-between hover:bg-white/5 transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-inset"
             >
                 <div className="flex items-center gap-2 text-sm font-medium text-white/80">
-                    <FileJson size={16} className="text-yellow-400" />
+                    <FileJson size={16} className="text-yellow-400" aria-hidden="true" />
                     <span>Sidecar Metadata</span>
                     {isLoading && <span className="text-xs text-white/40 ml-2">(Loading...)</span>}
                 </div>
-                {isOpen ? <ChevronDown size={16} className="text-white/40" /> : <ChevronRight size={16} className="text-white/40" />}
+                {isOpen ? <ChevronDown size={16} className="text-white/40" aria-hidden="true" /> : <ChevronRight size={16} className="text-white/40" aria-hidden="true" />}
             </button>
 
             {isOpen && data && (

--- a/frontend_v2/src/components/triage/MediaPreview.tsx
+++ b/frontend_v2/src/components/triage/MediaPreview.tsx
@@ -125,9 +125,10 @@ export default function MediaPreview({ filePath, fileType }: MediaPreviewProps) 
             <div className="p-3 flex items-center gap-3 bg-white/5 backdrop-blur-sm">
                 <button
                     onClick={togglePlay}
-                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white"
+                    aria-label={isPlaying ? "Pause video" : "Play video"}
+                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
                 >
-                    {isPlaying ? <Pause size={20} /> : <Play size={20} />}
+                    {isPlaying ? <Pause size={20} aria-hidden="true" /> : <Play size={20} aria-hidden="true" />}
                 </button>
 
                 <div className="flex-1 h-1 bg-white/10 rounded-full overflow-hidden">
@@ -139,9 +140,10 @@ export default function MediaPreview({ filePath, fileType }: MediaPreviewProps) 
 
                 <button
                     onClick={toggleMute}
-                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white/70"
+                    aria-label={isMuted ? "Unmute video" : "Mute video"}
+                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white/70 focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
                 >
-                    {isMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
+                    {isMuted ? <VolumeX size={18} aria-hidden="true" /> : <Volume2 size={18} aria-hidden="true" />}
                 </button>
             </div>
         </div>


### PR DESCRIPTION
💡 What: Added ARIA labels, aria-hidden for decorative SVGs, and focus-visible states to icon-only buttons in MediaPreview and JsonSidecarViewer.
🎯 Why: To improve screen reader context and keyboard navigation visibility for users relying on assistive tech.
📸 Before/After: Visual focus rings will now appear on `Tab`, and screen readers will announce button purposes correctly.
♿ Accessibility: Improved WCAG 2.1 AA compliance by adding programmatic names to icon buttons and visible focus indicators.

---
*PR created automatically by Jules for task [287976125820745572](https://jules.google.com/task/287976125820745572) started by @thebearwithabite*