### PR TITLE
🎨 Palette: Add accessible focus states and aria labels to ClassificationPreview buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,7 @@
 ## 2024-05-24 - Accessible Disconnected Banners
 **Learning:** Offline or disconnection warning banners (like `ConnectionStatus.tsx`) often bypass standard design system components and fail to announce themselves to screen readers upon mounting. Furthermore, their associated retry actions lack dynamic interaction text or explicit `aria-busy` state during asynchronous checks, leading to confusion during degraded system states.
 **Action:** Whenever introducing or modifying ad-hoc connection error banners, explicitly add `role="alert"` and `aria-live="assertive"` so screen readers announce them immediately. Any associated retry buttons must include `aria-busy`, explicit visual disabled states (`disabled:opacity-70`), and dynamic interaction text (e.g., "Retrying...") to provide clear feedback.
+
+## 2026-05-24 - Add accessible interactions to ClassificationPreview buttons
+**Learning:** Icon-only interactive elements in custom design system components often lack default browser focus indicators and explicit labels (aria-label/title) preventing screen reader access and keyboard navigation.
+**Action:** Always verify keyboard focus styles (`focus-visible:ring-2 focus-visible:outline-none`) and add explicit `aria-label` properties alongside `aria-hidden="true"` on inner SVG children.

--- a/frontend_v2/src/components/organize/ClassificationPreview.tsx
+++ b/frontend_v2/src/components/organize/ClassificationPreview.tsx
@@ -169,38 +169,40 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         <button
           onClick={handleConfirm}
           disabled={isConfirming}
-          className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-success hover:bg-success/90 rounded-xl font-medium transition-colors text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-success hover:bg-success/90 rounded-xl font-medium transition-colors text-white disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-success"
         >
           {isConfirming ? (
             <>
-              <Loader2 size={20} className="animate-spin" />
+              <Loader2 size={20} className="animate-spin" aria-hidden="true" />
               Organizing...
             </>
           ) : (
             <>
-              <Check size={20} />
+              <Check size={20} aria-hidden="true" />
               Confirm & Organize
             </>
           )}
         </button>
         <button
           onClick={handleReclassify}
-          className="flex items-center justify-center gap-2 px-4 py-3 bg-white/10 hover:bg-white/20 rounded-xl font-medium transition-colors text-white"
+          className="flex items-center justify-center gap-2 px-4 py-3 bg-white/10 hover:bg-white/20 rounded-xl font-medium transition-colors text-white focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
         >
-          <RefreshCw size={20} />
+          <RefreshCw size={20} aria-hidden="true" />
           Reclassify
         </button>
         <button
           onClick={handleSkip}
-          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white"
+          aria-label="Skip and close"
+          title="Skip and close"
+          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
         >
-          <X size={20} />
+          <X size={20} aria-hidden="true" />
         </button>
       </div>
 
       <button
         onClick={handleSkip}
-        className="w-full mt-3 text-sm text-white/60 hover:text-white transition-colors"
+        className="w-full mt-3 text-sm text-white/60 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50 rounded-lg p-2"
       >
         Skip (organize later)
       </button>


### PR DESCRIPTION
💡 What: Added explicit keyboard focus states (`focus-visible`) to action buttons in `ClassificationPreview`, added `aria-label` to the icon-only "skip" button, and marked internal SVG icons as `aria-hidden`.
🎯 Why: Icon-only buttons without an `aria-label` lack context for screen reader users. The lack of clear focus states prevents keyboard users from easily navigating the actions. Marking icons `aria-hidden` avoids redundant announcements when the button text already describes the action.
📸 Before/After: Before, buttons had no visible keyboard focus rings and the "X" button was unlabelled for screen readers. After, navigating by tab shows clear focus rings, and screen readers read "Skip and close" for the "X" button.
♿ Accessibility:
- Added `aria-label="Skip and close"` and `title="Skip and close"` to the X button.
- Added `aria-hidden="true"` to `Loader2`, `Check`, `RefreshCw`, and `X` lucide icons.
- Added `focus-visible:ring-2 focus-visible:outline-none` focus states on all interactive buttons.

---
*PR created automatically by Jules for task [18129640225211842949](https://jules.google.com/task/18129640225211842949) started by @thebearwithabite*