### PR TITLE
🎨 Palette: Add keyboard focus and ARIA labels to Classification Preview actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,6 @@
 ## 2024-05-24 - Accessible Disconnected Banners
 **Learning:** Offline or disconnection warning banners (like `ConnectionStatus.tsx`) often bypass standard design system components and fail to announce themselves to screen readers upon mounting. Furthermore, their associated retry actions lack dynamic interaction text or explicit `aria-busy` state during asynchronous checks, leading to confusion during degraded system states.
 **Action:** Whenever introducing or modifying ad-hoc connection error banners, explicitly add `role="alert"` and `aria-live="assertive"` so screen readers announce them immediately. Any associated retry buttons must include `aria-busy`, explicit visual disabled states (`disabled:opacity-70`), and dynamic interaction text (e.g., "Retrying...") to provide clear feedback.
+## 2024-05-27 - Keyboard Navigation in Custom Overlays
+**Learning:** Custom overlay UI components (like ClassificationPreview) often lack native browser focus rings and need explicit `focus-visible` definitions for primary interaction buttons, especially icon-only buttons which also omit `aria-label`s.
+**Action:** Always add explicit `focus-visible` utility classes and ensure icon-only control actions have a descriptive `aria-label` along with `aria-hidden="true"` on the SVG children in custom interactive panels.

--- a/frontend_v2/src/components/organize/ClassificationPreview.tsx
+++ b/frontend_v2/src/components/organize/ClassificationPreview.tsx
@@ -169,7 +169,7 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         <button
           onClick={handleConfirm}
           disabled={isConfirming}
-          className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-success hover:bg-success/90 rounded-xl font-medium transition-colors text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-success hover:bg-success/90 rounded-xl font-medium transition-colors text-white disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
         >
           {isConfirming ? (
             <>
@@ -185,22 +185,23 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         </button>
         <button
           onClick={handleReclassify}
-          className="flex items-center justify-center gap-2 px-4 py-3 bg-white/10 hover:bg-white/20 rounded-xl font-medium transition-colors text-white"
+          className="flex items-center justify-center gap-2 px-4 py-3 bg-white/10 hover:bg-white/20 rounded-xl font-medium transition-colors text-white focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
         >
           <RefreshCw size={20} />
           Reclassify
         </button>
         <button
           onClick={handleSkip}
-          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white"
+          aria-label="Skip file"
+          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
         >
-          <X size={20} />
+          <X size={20} aria-hidden="true" />
         </button>
       </div>
 
       <button
         onClick={handleSkip}
-        className="w-full mt-3 text-sm text-white/60 hover:text-white transition-colors"
+        className="w-full mt-3 text-sm text-white/60 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none rounded"
       >
         Skip (organize later)
       </button>


### PR DESCRIPTION
💡 What: Added `focus-visible` utility classes for keyboard navigation and an `aria-label` to the icon-only skip button in `ClassificationPreview.tsx`.
🎯 Why: Improves keyboard accessibility for users navigating the file classification UI. Icon-only buttons need descriptive labels for screen readers.
📸 Before/After: Visual focus states added via tailwind classes (`focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none`).
♿ Accessibility: Improved keyboard navigation and screen reader support.

---
*PR created automatically by Jules for task [15127135338510124934](https://jules.google.com/task/15127135338510124934) started by @thebearwithabite*