### PR TITLE
🎨 Palette: Add accessibility to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,6 @@
 ## 2024-05-24 - Accessible Disconnected Banners
 **Learning:** Offline or disconnection warning banners (like `ConnectionStatus.tsx`) often bypass standard design system components and fail to announce themselves to screen readers upon mounting. Furthermore, their associated retry actions lack dynamic interaction text or explicit `aria-busy` state during asynchronous checks, leading to confusion during degraded system states.
 **Action:** Whenever introducing or modifying ad-hoc connection error banners, explicitly add `role="alert"` and `aria-live="assertive"` so screen readers announce them immediately. Any associated retry buttons must include `aria-busy`, explicit visual disabled states (`disabled:opacity-70`), and dynamic interaction text (e.g., "Retrying...") to provide clear feedback.
+## 2024-05-31 - Add accessibility to icon-only buttons
+**Learning:** Icon-only buttons (like play/pause controls or X buttons) must have explicit `aria-label` or `title` attributes, their respective icons must have `aria-hidden="true"`, and the buttons must implement clear visual focus states (e.g., via `focus-visible`) for keyboard navigation.
+**Action:** Always verify that interactive icon-only elements have an accessible name and a clear focus indicator state.

--- a/frontend_v2/src/components/organize/ClassificationPreview.tsx
+++ b/frontend_v2/src/components/organize/ClassificationPreview.tsx
@@ -192,9 +192,11 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         </button>
         <button
           onClick={handleSkip}
-          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white"
+          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
+          aria-label="Skip"
+          title="Skip"
         >
-          <X size={20} />
+          <X size={20} aria-hidden="true" />
         </button>
       </div>
 

--- a/frontend_v2/src/components/triage/MediaPreview.tsx
+++ b/frontend_v2/src/components/triage/MediaPreview.tsx
@@ -125,9 +125,11 @@ export default function MediaPreview({ filePath, fileType }: MediaPreviewProps) 
             <div className="p-3 flex items-center gap-3 bg-white/5 backdrop-blur-sm">
                 <button
                     onClick={togglePlay}
-                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white"
+                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
+                    aria-label={isPlaying ? "Pause media" : "Play media"}
+                    title={isPlaying ? "Pause media" : "Play media"}
                 >
-                    {isPlaying ? <Pause size={20} /> : <Play size={20} />}
+                    {isPlaying ? <Pause size={20} aria-hidden="true" /> : <Play size={20} aria-hidden="true" />}
                 </button>
 
                 <div className="flex-1 h-1 bg-white/10 rounded-full overflow-hidden">
@@ -139,9 +141,11 @@ export default function MediaPreview({ filePath, fileType }: MediaPreviewProps) 
 
                 <button
                     onClick={toggleMute}
-                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white/70"
+                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white/70 focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
+                    aria-label={isMuted ? "Unmute media" : "Mute media"}
+                    title={isMuted ? "Unmute media" : "Mute media"}
                 >
-                    {isMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
+                    {isMuted ? <VolumeX size={18} aria-hidden="true" /> : <Volume2 size={18} aria-hidden="true" />}
                 </button>
             </div>
         </div>


### PR DESCRIPTION
- 💡 What: Added `aria-label`, `title`, and `focus-visible` classes to the icon-only buttons in `MediaPreview.tsx` and `ClassificationPreview.tsx`. Also added `aria-hidden="true"` to their respective icons.
- 🎯 Why: To improve accessibility for screen readers and keyboard users for these icon-only buttons.
- 📸 Before/After: Before, the buttons lacked aria labels and focus indicators, relying purely on icons and visual feedback. After, the buttons have aria labels, tooltips, and explicit keyboard focus states.
- ♿ Accessibility: Screen reader users will now be able to understand the function of these buttons, and keyboard users will have clear visual indicators of their current focus state.

---
*PR created automatically by Jules for task [16765606788171539823](https://jules.google.com/task/16765606788171539823) started by @thebearwithabite*