### PR TITLE
🎨 Palette: Add accessibility to MediaPreview controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,7 @@
 ## 2024-05-24 - Accessible Disconnected Banners
 **Learning:** Offline or disconnection warning banners (like `ConnectionStatus.tsx`) often bypass standard design system components and fail to announce themselves to screen readers upon mounting. Furthermore, their associated retry actions lack dynamic interaction text or explicit `aria-busy` state during asynchronous checks, leading to confusion during degraded system states.
 **Action:** Whenever introducing or modifying ad-hoc connection error banners, explicitly add `role="alert"` and `aria-live="assertive"` so screen readers announce them immediately. Any associated retry buttons must include `aria-busy`, explicit visual disabled states (`disabled:opacity-70`), and dynamic interaction text (e.g., "Retrying...") to provide clear feedback.
+
+## 2026-06-06 - Added ARIA labels and focus states to MediaPreview controls
+**Learning:** Icon-only buttons in custom media players often lack accessible names, breaking screen reader functionality. Also, without custom focus states (`focus-visible:ring-2`), keyboard navigation context is lost, particularly on dark backgrounds where default browser rings might be invisible. Dynamic `aria-label`s (like "Play" vs "Pause") are essential for toggle states.
+**Action:** Always ensure icon-only buttons have explicit `aria-label`s, apply `aria-hidden="true"` to the inner SVG icons to avoid redundant screen reader noise, and add standard `focus-visible` utility classes to guarantee keyboard focus visibility.

--- a/frontend_v2/src/components/triage/MediaPreview.tsx
+++ b/frontend_v2/src/components/triage/MediaPreview.tsx
@@ -125,9 +125,10 @@ export default function MediaPreview({ filePath, fileType }: MediaPreviewProps) 
             <div className="p-3 flex items-center gap-3 bg-white/5 backdrop-blur-sm">
                 <button
                     onClick={togglePlay}
-                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white"
+                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
+                    aria-label={isPlaying ? "Pause" : "Play"}
                 >
-                    {isPlaying ? <Pause size={20} /> : <Play size={20} />}
+                    {isPlaying ? <Pause size={20} aria-hidden="true" /> : <Play size={20} aria-hidden="true" />}
                 </button>
 
                 <div className="flex-1 h-1 bg-white/10 rounded-full overflow-hidden">
@@ -139,9 +140,10 @@ export default function MediaPreview({ filePath, fileType }: MediaPreviewProps) 
 
                 <button
                     onClick={toggleMute}
-                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white/70"
+                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white/70 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
+                    aria-label={isMuted ? "Unmute" : "Mute"}
                 >
-                    {isMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
+                    {isMuted ? <VolumeX size={18} aria-hidden="true" /> : <Volume2 size={18} aria-hidden="true" />}
                 </button>
             </div>
         </div>


### PR DESCRIPTION
💡 What:
Added `aria-label`s and `focus-visible` states to the play/pause and mute/unmute buttons in `MediaPreview.tsx`. Also added `aria-hidden="true"` to the nested SVG icons.

🎯 Why:
Icon-only media control buttons are inaccessible to screen readers without explicit labels. Additionally, custom components often lack default browser focus rings, making keyboard navigation difficult or impossible on dark backgrounds. Dynamic aria labels ensure the state (Play vs Pause) is clearly communicated.

📸 Before/After:
Before: Buttons lacked `aria-label`s and focus rings. Screen readers would read "button" without context.
After: Buttons announce their state (e.g., "Play, button") and show a visible ring when focused via keyboard.

♿ Accessibility:
- Added `aria-label` to dynamically announce "Play"/"Pause" and "Mute"/"Unmute"
- Added `aria-hidden="true"` to SVG children to prevent redundant reading
- Added `focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none` for clear keyboard focus indicators

---
*PR created automatically by Jules for task [18243798884806448532](https://jules.google.com/task/18243798884806448532) started by @thebearwithabite*