### PR TITLE
🎨 Palette: Add accessibility attributes to icon-only buttons in TaxonomySettings

### DIFF
--- a/frontend_v2/src/components/settings/TaxonomySettings.tsx
+++ b/frontend_v2/src/components/settings/TaxonomySettings.tsx
@@ -219,18 +219,20 @@ export const TaxonomySettings: React.FC = () => {
                                             <button
                                                 onClick={() => handleEditOpen(cat)}
                                                 disabled={cat.locked}
-                                                className="p-2 hover:bg-white/10 rounded-lg text-white/60 hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                                                className="p-2 hover:bg-white/10 rounded-lg text-white/60 hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-primary"
                                                 title="Edit Metadata"
+                                                aria-label={`Edit metadata for ${cat.display_name}`}
                                             >
-                                                <Edit size={18} />
+                                                <Edit size={18} aria-hidden="true" />
                                             </button>
                                             <button
                                                 onClick={() => handleRenameOpen(cat)}
                                                 disabled={cat.locked}
-                                                className="p-2 hover:bg-white/10 rounded-lg text-white/60 hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                                                className="p-2 hover:bg-white/10 rounded-lg text-white/60 hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-primary"
                                                 title="Rename Category & Folder"
+                                                aria-label={`Rename category and folder for ${cat.display_name}`}
                                             >
-                                                <FolderEdit size={18} />
+                                                <FolderEdit size={18} aria-hidden="true" />
                                             </button>
                                         </div>
                                     </td>


### PR DESCRIPTION
💡 What:
Added `aria-label` and `focus-visible` classes to the `Edit` and `FolderEdit` icon-only buttons in the `TaxonomySettings` component. Added `aria-hidden="true"` to the internal SVG icons.

🎯 Why:
Icon-only buttons must have an accessible name for screen reader users and explicit visual focus states for keyboard navigation, as custom UI components often lack default browser focus indicators.

📸 Before/After:
Before: `<button title="Edit Metadata"><Edit size={18} /></button>` (not focusable with visual indication, no screen reader text).
After: `<button aria-label="Edit metadata for Test Category" className="... focus-visible:ring-2 ..."><Edit size={18} aria-hidden="true" /></button>`

♿ Accessibility:
- Screen readers will now announce the specific category being edited or renamed.
- Keyboard users can clearly see when these action buttons receive focus.
- Prevents redundant announcements from nested SVGs.

---
*PR created automatically by Jules for task [8436035681291059692](https://jules.google.com/task/8436035681291059692) started by @thebearwithabite*