### PR TITLE
🎨 Palette: Add accessibility improvements to skip button in Classification Preview

### DIFF
--- a/frontend_v2/src/components/organize/ClassificationPreview.tsx
+++ b/frontend_v2/src/components/organize/ClassificationPreview.tsx
@@ -192,9 +192,10 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         </button>
         <button
           onClick={handleSkip}
-          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white"
+          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
+          aria-label="Skip and close preview"
         >
-          <X size={20} />
+          <X size={20} aria-hidden="true" />
         </button>
       </div>
 


### PR DESCRIPTION
💡 What: Added an explicit `aria-label`, `aria-hidden` on the SVG, and keyboard `focus-visible` styles to the icon-only skip button in `ClassificationPreview.tsx`.
🎯 Why: The previous button lacked an accessible name and visual focus indicators, making it hard to use for keyboard navigators and screen readers.
📸 Before/After: Visual outline appears on keyboard focus, and screen reader reads "Skip and close preview" instead of skipping over the button or reading generic text.
♿ Accessibility: Added `aria-label` to provide accessible name. Added `aria-hidden="true"` to SVG to avoid redundant screen reader noise. Added `focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none` for proper keyboard focus state.

---
*PR created automatically by Jules for task [12661782523255534897](https://jules.google.com/task/12661782523255534897) started by @thebearwithabite*