### PR TITLE
🎨 Palette: Add accessibility and focus states to IdentityManager icon buttons

### DIFF
--- a/frontend_v2/src/components/settings/IdentityManager.tsx
+++ b/frontend_v2/src/components/settings/IdentityManager.tsx
@@ -44,8 +44,8 @@ export default function IdentityManager() {
             setLoading(true)
             const data = await identityService.getIdentities()
             setIdentities(data)
-        } catch (err) {
-            console.error(err)
+        } catch {
+            console.error("Failed to load identities")
             toast.error('Failed to load "World Model" registry')
         } finally {
             setLoading(false)
@@ -89,7 +89,7 @@ export default function IdentityManager() {
             }
             setIsDialogOpen(false)
             fetchIdentities()
-        } catch (err) {
+        } catch {
             toast.error('Failed to save identity')
         }
     }
@@ -101,7 +101,7 @@ export default function IdentityManager() {
             await identityService.deleteIdentity(id)
             toast.success('Identity removed')
             fetchIdentities()
-        } catch (err) {
+        } catch {
             toast.error('Failed to delete identity')
         }
     }
@@ -187,15 +187,19 @@ export default function IdentityManager() {
                                 <div className="flex gap-1">
                                     <button
                                         onClick={() => handleOpenDialog(identity)}
-                                        className="p-1.5 text-white/40 hover:text-white hover:bg-white/10 rounded-lg transition-colors"
+                                        className="p-1.5 text-white/40 hover:text-white hover:bg-white/10 rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-purple-500/50 focus-visible:outline-none"
+                                        aria-label={`Edit ${identity.name}`}
+                                        title={`Edit ${identity.name}`}
                                     >
-                                        <Edit2 size={14} />
+                                        <Edit2 size={14} aria-hidden="true" />
                                     </button>
                                     <button
                                         onClick={() => handleDelete(identity.id)}
-                                        className="p-1.5 text-white/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors"
+                                        className="p-1.5 text-white/40 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-purple-500/50 focus-visible:outline-none"
+                                        aria-label={`Delete ${identity.name}`}
+                                        title={`Delete ${identity.name}`}
                                     >
-                                        <Trash2 size={14} />
+                                        <Trash2 size={14} aria-hidden="true" />
                                     </button>
                                 </div>
                             </div>
@@ -239,9 +243,11 @@ export default function IdentityManager() {
                             </h2>
                             <button
                                 onClick={() => setIsDialogOpen(false)}
-                                className="p-2 text-white/40 hover:text-white transition-colors"
+                                className="p-2 text-white/40 hover:text-white transition-colors rounded-lg focus-visible:ring-2 focus-visible:ring-purple-500/50 focus-visible:outline-none"
+                                aria-label="Close dialog"
+                                title="Close dialog"
                             >
-                                <X size={20} />
+                                <X size={20} aria-hidden="true" />
                             </button>
                         </div>
 


### PR DESCRIPTION
💡 What: Added `aria-label`, `title`, and `focus-visible` ring styling (`focus-visible:ring-2 focus-visible:ring-purple-500/50 focus-visible:outline-none rounded-lg`) to the Edit, Delete, and Close Dialog icon-only buttons in the IdentityManager component. Added `aria-hidden="true"` to their internal SVG icons. Fixed unused `err` variables in `catch` blocks.
🎯 Why: Icon-only buttons without accessible names cannot be interpreted by screen readers. Missing focus outlines make keyboard navigation extremely difficult for users relying on non-mouse input. Tooltips provide contextual help for all visual users.
📸 Before/After: Visual purple focus ring outline now properly appears during keyboard tabbing.
♿ Accessibility: Resolves WCAG 2.1 violations for missing ARIA labels (SC 4.1.2) and lack of visible focus indicators (SC 2.4.7). Prevents screen readers from redundantly reading inner SVGs.

---
*PR created automatically by Jules for task [9959977217709302902](https://jules.google.com/task/9959977217709302902) started by @thebearwithabite*