### PR TITLE
🎨 Palette: Add focus states to Confidence Mode buttons

### DIFF
--- a/frontend_v2/src/components/organize/ConfidenceModeSelector.tsx
+++ b/frontend_v2/src/components/organize/ConfidenceModeSelector.tsx
@@ -40,7 +40,7 @@ export default function ConfidenceModeSelector() {
   const [selectedMode, setSelectedMode] = useState('smart')
 
   const { mutate: updateMode } = useMutation({
-    mutationFn: (mode: string) => api.setConfidenceMode(mode as any),
+    mutationFn: (mode: string) => api.setConfidenceMode(mode as "never" | "minimal" | "smart" | "always"),
     onSuccess: () => {
       toast.success('Confidence mode updated')
     },
@@ -64,7 +64,7 @@ export default function ConfidenceModeSelector() {
             key={mode.value}
             onClick={() => handleModeChange(mode.value)}
             className={cn(
-              "w-full text-left p-4 rounded-xl border-2 transition-all",
+              "w-full text-left p-4 rounded-xl border-2 transition-all focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900",
               selectedMode === mode.value
                 ? "border-primary bg-primary/10"
                 : "border-white/10 bg-white/[0.05] hover:border-white/20"


### PR DESCRIPTION
💡 What: Added `focus-visible` utility classes to the mode selection buttons in the `ConfidenceModeSelector` component. Replaced an `any` cast with a strict union type.
🎯 Why: Keyboard users previously lacked visual feedback when navigating through the confidence mode options, as the buttons did not have defined focus states. This change makes it clear which mode is currently focused during keyboard navigation.
📸 Before/After: N/A (Visual state change on keyboard interaction)
♿ Accessibility: Improves keyboard navigation support by ensuring interactive elements have a clear, visible focus indicator, aligning with WCAG criteria for Focus Visible.

---
*PR created automatically by Jules for task [13040154287567070021](https://jules.google.com/task/13040154287567070021) started by @thebearwithabite*