### PR TITLE
🎨 Palette: Add focus-visible states to LogViewer tabs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,6 @@
 ## 2024-05-24 - Accessible Disconnected Banners
 **Learning:** Offline or disconnection warning banners (like `ConnectionStatus.tsx`) often bypass standard design system components and fail to announce themselves to screen readers upon mounting. Furthermore, their associated retry actions lack dynamic interaction text or explicit `aria-busy` state during asynchronous checks, leading to confusion during degraded system states.
 **Action:** Whenever introducing or modifying ad-hoc connection error banners, explicitly add `role="alert"` and `aria-live="assertive"` so screen readers announce them immediately. Any associated retry buttons must include `aria-busy`, explicit visual disabled states (`disabled:opacity-70`), and dynamic interaction text (e.g., "Retrying...") to provide clear feedback.
+## 2024-06-20 - Ensure Keyboard Navigation Uses focus-visible Utility Classes
+**Learning:** Interactive components built without standard HTML controls (e.g. ad-hoc tabs, custom dropdowns) often lose default browser keyboard focus rings.
+**Action:** Always ensure that interactive elements manually mapped to `<button>` or custom components have explicit `focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-primary` utility classes to satisfy basic keyboard accessibility requirements without compromising the mouse/touch visual design.

--- a/frontend_v2/src/components/dashboard/LogViewer.tsx
+++ b/frontend_v2/src/components/dashboard/LogViewer.tsx
@@ -92,7 +92,7 @@ export default function LogViewer() {
                         <button
                             key={tab}
                             onClick={() => setActiveTab(tab)}
-                            className={`px-3 py-1 text-xs font-medium rounded-md transition-all ${activeTab === tab
+                            className={`px-3 py-1 text-xs font-medium rounded-md transition-all focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none ${activeTab === tab
                                 ? 'bg-white/10 text-white shadow-sm'
                                 : 'text-white/40 hover:text-white/70'
                                 }`}


### PR DESCRIPTION
💡 What: Added explicit `focus-visible` utility classes (`focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none`) to the LogViewer tab buttons ('All', 'Maintenance', 'Emergency').
🎯 Why: Tab buttons lacked keyboard focus indicators, making it difficult for keyboard users to know which tab was currently focused.
📸 Before/After: Tab buttons previously showed no visual change on focus. They now display a primary colored focus ring.
♿ Accessibility: Improved keyboard navigation compliance by making interactive elements clearly visible when focused via the keyboard.

---
*PR created automatically by Jules for task [17888291395162496316](https://jules.google.com/task/17888291395162496316) started by @thebearwithabite*