### PR TITLE
🎨 Palette: [UX improvement] Add accessibility attributes to search form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,6 @@
 ## 2024-05-24 - Accessible Disconnected Banners
 **Learning:** Offline or disconnection warning banners (like `ConnectionStatus.tsx`) often bypass standard design system components and fail to announce themselves to screen readers upon mounting. Furthermore, their associated retry actions lack dynamic interaction text or explicit `aria-busy` state during asynchronous checks, leading to confusion during degraded system states.
 **Action:** Whenever introducing or modifying ad-hoc connection error banners, explicitly add `role="alert"` and `aria-live="assertive"` so screen readers announce them immediately. Any associated retry buttons must include `aria-busy`, explicit visual disabled states (`disabled:opacity-70`), and dynamic interaction text (e.g., "Retrying...") to provide clear feedback.
+## 2024-06-21 - Accessible Search Forms
+**Learning:** Search components relying solely on an icon or placeholder text are insufficient for screen readers. The wrapping form requires an explicit role, and the input needs a label.
+**Action:** Always add `role="search"` to the `<form>` element encompassing a search input. The input itself must have an `aria-label` (e.g., `aria-label="Search files"`) if a visible `<label>` is not present.

--- a/frontend_v2/src/pages/Search.tsx
+++ b/frontend_v2/src/pages/Search.tsx
@@ -53,9 +53,9 @@ export default function Search() {
     try {
       await api.openFile(filePath)
       toast.success('Opening file...')
-    } catch (error: any) {
+    } catch (error) {
       toast.error('Failed to open file', {
-        description: error.message,
+        description: error instanceof Error ? error.message : 'Unknown error',
       })
     }
   }
@@ -96,10 +96,11 @@ export default function Search() {
       </div>
 
       {/* Search Form */}
-      <form onSubmit={handleSearch} className="relative">
+      <form role="search" onSubmit={handleSearch} className="relative">
         <div className="relative">
           <SearchIcon className="absolute left-4 top-1/2 transform -translate-y-1/2 text-white/40" size={20} />
           <input
+            aria-label="Search files"
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}


### PR DESCRIPTION
💡 What:
Added `role="search"` to the search form wrapper and an explicit `aria-label="Search files"` to the main search input field. Also fixed an explicit `any` in a try/catch block.

🎯 Why:
To improve accessibility for screen reader users by explicitly defining the search region and providing an accessible name for the search input field. The typescript fix was required to satisfy the linter.

📸 Before/After:
Before: Form lacked `role="search"` and input lacked an accessible name, making it harder for screen reader users to identify the search functionality.
After: Form explicitly declared as a search region and input clearly labeled.

♿ Accessibility:
- Screen readers can now easily locate the search region using landmark navigation.
- The search input now has a descriptive name announced to assistive technologies.

---
*PR created automatically by Jules for task [7258495958046171892](https://jules.google.com/task/7258495958046171892) started by @thebearwithabite*