### PR TITLE
🎨 Palette: Add keyboard focus states to ShotCard buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,7 @@
 ## 2024-05-24 - Accessible Disconnected Banners
 **Learning:** Offline or disconnection warning banners (like `ConnectionStatus.tsx`) often bypass standard design system components and fail to announce themselves to screen readers upon mounting. Furthermore, their associated retry actions lack dynamic interaction text or explicit `aria-busy` state during asynchronous checks, leading to confusion during degraded system states.
 **Action:** Whenever introducing or modifying ad-hoc connection error banners, explicitly add `role="alert"` and `aria-live="assertive"` so screen readers announce them immediately. Any associated retry buttons must include `aria-busy`, explicit visual disabled states (`disabled:opacity-70`), and dynamic interaction text (e.g., "Retrying...") to provide clear feedback.
+
+## 2024-05-18 - Missing focus-visible on complex custom components
+**Learning:** In the `ShotCard` component, complex custom styled buttons (with custom background blurs, hover effects, and shadow layers) completely lacked explicit `focus-visible` states, rendering them invisible to keyboard-only navigation despite being fully interactive buttons.
+**Action:** Always verify keyboard accessibility on custom-styled interactive components. Apply explicit `focus-visible:ring-2 focus-visible:outline-none` with context-aware ring colors (e.g., `focus-visible:ring-indigo-400` for an indigo button) to match the component's aesthetic without sacrificing accessibility.

--- a/frontend_v2/src/components/veo/ShotCard.tsx
+++ b/frontend_v2/src/components/veo/ShotCard.tsx
@@ -102,7 +102,7 @@ const ShotCard: React.FC<ShotCardProps> = ({
                                     setCopyButtonText('Copied!');
                                     setTimeout(() => setCopyButtonText('Copy JSON'), 2000);
                                 }}
-                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all"
+                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
                             >
                                 {copyButtonText}
                             </button>
@@ -114,14 +114,14 @@ const ShotCard: React.FC<ShotCardProps> = ({
                             {!shot.isApproved ? (
                                 <button
                                     onClick={() => onApproveShot(shot.id, true)}
-                                    className="px-8 py-3.5 bg-indigo-600 hover:bg-indigo-500 text-white font-black rounded-2xl text-[10px] uppercase tracking-widest italic transition-all shadow-[0_10px_30px_rgba(79,70,229,0.3)]"
+                                    className="px-8 py-3.5 bg-indigo-600 hover:bg-indigo-500 text-white font-black rounded-2xl text-[10px] uppercase tracking-widest italic transition-all shadow-[0_10px_30px_rgba(79,70,229,0.3)] focus-visible:ring-2 focus-visible:ring-indigo-400 focus-visible:outline-none"
                                 >
                                     Lock Sequence
                                 </button>
                             ) : (
                                 <button
                                     onClick={() => onApproveShot(shot.id, false)}
-                                    className="px-8 py-3.5 bg-white/5 text-white/40 hover:text-white rounded-2xl text-[10px] font-black uppercase tracking-widest border border-white/5 transition-all"
+                                    className="px-8 py-3.5 bg-white/5 text-white/40 hover:text-white rounded-2xl text-[10px] font-black uppercase tracking-widest border border-white/5 transition-all focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
                                 >
                                     Unlock
                                 </button>
@@ -133,7 +133,7 @@ const ShotCard: React.FC<ShotCardProps> = ({
                                 <button
                                     onClick={() => onGenerateVideo(shot.id, useKeyframeAsReference)}
                                     disabled={!shot.isApproved}
-                                    className={`px-8 py-3.5 rounded-2xl text-[10px] font-black uppercase tracking-widest italic transition-all ${shot.isApproved ? 'bg-pink-600 hover:bg-pink-500 text-white shadow-[0_10px_30px_rgba(219,39,119,0.3)]' : 'bg-white/5 text-white/5 cursor-not-allowed'}`}
+                                    className={`px-8 py-3.5 rounded-2xl text-[10px] font-black uppercase tracking-widest italic transition-all focus-visible:ring-2 focus-visible:ring-pink-400 focus-visible:outline-none ${shot.isApproved ? 'bg-pink-600 hover:bg-pink-500 text-white shadow-[0_10px_30px_rgba(219,39,119,0.3)]' : 'bg-white/5 text-white/5 cursor-not-allowed'}`}
                                 >
                                     Generate Video
                                 </button>


### PR DESCRIPTION
💡 What: Added explicit keyboard focus states (`focus-visible`) to the action buttons inside the `ShotCard` component.
🎯 Why: The buttons previously only had hover states, making them difficult or impossible to identify when navigating via keyboard. This small addition makes the component accessible to keyboard and screen reader users.
📸 Before/After: N/A
♿ Accessibility: Added `focus-visible:ring-2`, `focus-visible:outline-none`, and contextually colored rings to Ensure keyboard accessibility (focus states, tab order).

---
*PR created automatically by Jules for task [18080989567421532455](https://jules.google.com/task/18080989567421532455) started by @thebearwithabite*