### PR TITLE
🎨 Palette: Make "Copy JSON" button keyboard accessible

### DIFF
--- a/frontend_v2/src/components/veo/ShotCard.tsx
+++ b/frontend_v2/src/components/veo/ShotCard.tsx
@@ -95,14 +95,15 @@ const ShotCard: React.FC<ShotCardProps> = ({
                         <pre className="text-indigo-400/80 leading-relaxed">
                             <code>{shot.veoJson ? JSON.stringify(shot.veoJson, null, 2) : '// Awaiting Director Breakdown...'}</code>
                         </pre>
-                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 transition-all translate-y-2 group-hover:translate-y-0">
+                        <div className="absolute top-4 right-4 flex gap-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-all translate-y-2 group-hover:translate-y-0 focus-within:translate-y-0">
                             <button
                                 onClick={() => {
                                     navigator.clipboard.writeText(JSON.stringify(shot.veoJson, null, 2));
                                     setCopyButtonText('Copied!');
                                     setTimeout(() => setCopyButtonText('Copy JSON'), 2000);
                                 }}
-                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all"
+                                className="px-3 py-1.5 bg-white/10 backdrop-blur-md rounded-lg hover:bg-white/20 text-white text-[9px] font-black uppercase tracking-widest transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none focus-visible:opacity-100"
+                                aria-label="Copy JSON"
                             >
                                 {copyButtonText}
                             </button>


### PR DESCRIPTION
💡 What: Added focus-visible and focus-within styles to the "Copy JSON" button in ShotCard, and an aria-label.
🎯 Why: The button was hidden behind opacity-0 and group-hover:opacity-100, rendering it completely inaccessible to keyboard-only users traversing with Tab.
📸 Before/After: N/A
♿ Accessibility: Ensured the button and its parent wrapper become visible and properly styled when receiving keyboard focus.

---
*PR created automatically by Jules for task [15926894031677336752](https://jules.google.com/task/15926894031677336752) started by @thebearwithabite*