### PR TITLE
🎨 Palette: Make disk space tooltips and buttons keyboard accessible

### DIFF
--- a/frontend_v2/src/components/dashboard/DiskSpaceWidget.tsx
+++ b/frontend_v2/src/components/dashboard/DiskSpaceWidget.tsx
@@ -102,12 +102,16 @@ export default function DiskSpaceWidget() {
       <div className="flex items-center gap-2 mb-4">
         <HardDrive size={20} className="text-purple-400" />
         <h2 className="text-xl font-semibold text-white">Disk Space Protection</h2>
-        <div className="group relative ml-auto">
-          <Info size={16} className="text-white/40 hover:text-white/60 cursor-help transition-colors" />
-          <div className="invisible group-hover:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl">
+        <button
+          type="button"
+          className="group relative ml-auto focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded"
+          aria-label="Disk space protection info"
+        >
+          <Info size={16} aria-hidden="true" className="text-white/40 group-hover:text-white/60 group-focus-visible:text-white/60 cursor-help transition-colors" />
+          <div className="invisible group-hover:visible group-focus:visible absolute right-0 top-6 w-72 p-3 bg-black/90 backdrop-blur-xl border border-white/20 rounded-lg text-xs text-white/80 z-10 shadow-xl text-left pointer-events-none">
             Monitors disk space and prevents "disk full" crises. Automatically protects against space issues before they happen. ADHD-friendly: eliminates panic moments from sudden space issues.
           </div>
-        </div>
+        </button>
       </div>
 
       {/* Disk Usage Stats */}
@@ -177,7 +181,7 @@ export default function DiskSpaceWidget() {
           <button
             onClick={handleFreeUpSpace}
             disabled={isCleaning}
-            className={`w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg font-medium transition-all duration-200 ${status?.threshold_95
+            className={`w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg font-medium transition-all duration-200 focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 ${status?.threshold_95
               ? 'bg-destructive hover:bg-destructive/80 text-white shadow-lg'
               : 'bg-warning hover:bg-warning/80 text-black shadow-lg'
               } disabled:opacity-50 disabled:cursor-not-allowed`}


### PR DESCRIPTION
💡 What: Added standard keyboard accessibility focus states to the informational tooltip and "Free Up Space" button within the `DiskSpaceWidget`.
🎯 Why: To ensure users with screen readers or who navigate strictly via keyboard can interact with system notifications and successfully invoke emergency disk space protections without resorting to a mouse.
📸 Before/After: N/A - Only CSS focus-visible state modifications.
♿ Accessibility: 
- Wrapped the tooltip inside a semantically correct `<button>` structure, applying `aria-label`, `aria-hidden` and explicitly applying `group-focus:visible` to reveal the tooltip visually upon tab focus.
- Injected explicit `focus-visible` UI ring highlights onto both the tooltip and action button to guarantee keyboard focus tracking matches mouse interactions.

---
*PR created automatically by Jules for task [5922665131895646367](https://jules.google.com/task/5922665131895646367) started by @thebearwithabite*