### PR TITLE
🎨 Palette: Add keyboard focus states and ARIA labels to Classification Preview buttons

### DIFF
--- a/frontend_v2/src/components/organize/ClassificationPreview.tsx
+++ b/frontend_v2/src/components/organize/ClassificationPreview.tsx
@@ -169,7 +169,7 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         <button
           onClick={handleConfirm}
           disabled={isConfirming}
-          className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-success hover:bg-success/90 rounded-xl font-medium transition-colors text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-success hover:bg-success/90 rounded-xl font-medium transition-colors text-white disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
         >
           {isConfirming ? (
             <>
@@ -185,22 +185,23 @@ export default function ClassificationPreview({ result, onClose }: Classificatio
         </button>
         <button
           onClick={handleReclassify}
-          className="flex items-center justify-center gap-2 px-4 py-3 bg-white/10 hover:bg-white/20 rounded-xl font-medium transition-colors text-white"
+          className="flex items-center justify-center gap-2 px-4 py-3 bg-white/10 hover:bg-white/20 rounded-xl font-medium transition-colors text-white focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
         >
           <RefreshCw size={20} />
           Reclassify
         </button>
         <button
           onClick={handleSkip}
-          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white"
+          aria-label="Skip"
+          className="p-3 bg-white/10 hover:bg-white/20 rounded-xl transition-colors text-white focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
         >
-          <X size={20} />
+          <X size={20} aria-hidden="true" />
         </button>
       </div>
 
       <button
         onClick={handleSkip}
-        className="w-full mt-3 text-sm text-white/60 hover:text-white transition-colors"
+        className="w-full mt-3 text-sm text-white/60 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none rounded-lg"
       >
         Skip (organize later)
       </button>


### PR DESCRIPTION
💡 What: Added `focus-visible` Tailwind classes to the action buttons in the `ClassificationPreview` component and an `aria-label` to the Skip icon button.
🎯 Why: To improve keyboard navigation accessibility and ensure screen readers can correctly announce the skip button.
📸 Before/After: The buttons previously had no visible focus ring when navigating via keyboard; they now display a clear primary ring. The skip icon was announced ambiguously, but now correctly says "Skip".
♿ Accessibility: Added `focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none` for keyboard focus indicators, `aria-label="Skip"`, and `aria-hidden="true"` on the SVG icon.

---
*PR created automatically by Jules for task [7716341622572672453](https://jules.google.com/task/7716341622572672453) started by @thebearwithabite*