### PR TITLE
🎨 Palette: Add keyboard focus styles to Confidence Mode selector

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-07-01 - Confidence Mode Selector Keyboard Accessibility
+**Learning:** Custom interactive components mapped as lists of buttons (like the `ConfidenceModeSelector`) frequently omit default `focus-visible` styles, rendering them invisible to keyboard navigation. We also noticed an implicit `any` type casting on the backend API call parameter for the selector component.
+**Action:** Always add explicit `focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none` utilities to custom button selectors in Tailwind. Replace `any` casts with proper type imports like `ConfidenceMode` to ensure type safety.

--- a/frontend_v2/src/components/organize/ConfidenceModeSelector.tsx
+++ b/frontend_v2/src/components/organize/ConfidenceModeSelector.tsx
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { api } from '../../services/api'
 import { cn } from '../../lib/utils'
+import type { ConfidenceMode } from '../../types/api'
 
 const modes = [
   {
@@ -40,7 +41,7 @@ export default function ConfidenceModeSelector() {
   const [selectedMode, setSelectedMode] = useState('smart')
 
   const { mutate: updateMode } = useMutation({
-    mutationFn: (mode: string) => api.setConfidenceMode(mode as any),
+    mutationFn: (mode: string) => api.setConfidenceMode(mode as ConfidenceMode),
     onSuccess: () => {
       toast.success('Confidence mode updated')
     },
@@ -64,7 +65,7 @@ export default function ConfidenceModeSelector() {
             key={mode.value}
             onClick={() => handleModeChange(mode.value)}
             className={cn(
-              "w-full text-left p-4 rounded-xl border-2 transition-all",
+              "w-full text-left p-4 rounded-xl border-2 transition-all focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none",
               selectedMode === mode.value
                 ? "border-primary bg-primary/10"
                 : "border-white/10 bg-white/[0.05] hover:border-white/20"


### PR DESCRIPTION
💡 What: Added `focus-visible` utility classes to the Confidence Mode selector buttons and fixed a typescript `any` cast.
🎯 Why: The buttons were previously lacking visual feedback for keyboard navigation, making it difficult for keyboard users to know which mode was currently in focus. Additionally, a strict ESLint typing error was flagged and resolved.
📸 Before/After: Not applicable (visual interaction change only).
♿ Accessibility: Added `focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none` to improve keyboard accessibility and comply with WCAG 2.1 Focus Visible guidelines.

---
*PR created automatically by Jules for task [8838157117623874343](https://jules.google.com/task/8838157117623874343) started by @thebearwithabite*