### PR TITLE
🎨 Palette: Add keyboard focus and ARIA roles to LogViewer tabs

### DIFF
--- a/frontend_v2/src/components/dashboard/LogViewer.tsx
+++ b/frontend_v2/src/components/dashboard/LogViewer.tsx
@@ -87,12 +87,14 @@ export default function LogViewer() {
                     <h2 className="text-xl font-semibold text-white">System Logs</h2>
                 </div>
 
-                <div className="flex bg-white/5 p-1 rounded-lg">
+                <div className="flex bg-white/5 p-1 rounded-lg" role="tablist" aria-label="Log categories">
                     {(['all', 'maintenance', 'emergency'] as const).map(tab => (
                         <button
                             key={tab}
+                            role="tab"
+                            aria-selected={activeTab === tab}
                             onClick={() => setActiveTab(tab)}
-                            className={`px-3 py-1 text-xs font-medium rounded-md transition-all ${activeTab === tab
+                            className={`px-3 py-1 text-xs font-medium rounded-md transition-all focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-primary ${activeTab === tab
                                 ? 'bg-white/10 text-white shadow-sm'
                                 : 'text-white/40 hover:text-white/70'
                                 }`}

--- a/frontend_v2/src/components/triage/MediaPreview.tsx
+++ b/frontend_v2/src/components/triage/MediaPreview.tsx
@@ -125,7 +125,9 @@ export default function MediaPreview({ filePath, fileType }: MediaPreviewProps) 
             <div className="p-3 flex items-center gap-3 bg-white/5 backdrop-blur-sm">
                 <button
                     onClick={togglePlay}
-                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white"
+                    aria-label={isPlaying ? "Pause media" : "Play media"}
+                    title={isPlaying ? "Pause" : "Play"}
+                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-primary"
                 >
                     {isPlaying ? <Pause size={20} /> : <Play size={20} />}
                 </button>
@@ -139,7 +141,9 @@ export default function MediaPreview({ filePath, fileType }: MediaPreviewProps) 
 
                 <button
                     onClick={toggleMute}
-                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white/70"
+                    aria-label={isMuted ? "Unmute media" : "Mute media"}
+                    title={isMuted ? "Unmute" : "Mute"}
+                    className="p-2 hover:bg-white/10 rounded-full transition-colors text-white/70 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-primary"
                 >
                     {isMuted ? <VolumeX size={18} /> : <Volume2 size={18} />}
                 </button>


### PR DESCRIPTION
💡 What: Added `role="tablist"` to the LogViewer tab container, `role="tab"` to the buttons, `aria-selected` tracking, and `focus-visible` styles for keyboard navigation.
🎯 Why: The tab buttons previously lacked any visual indicator when focused via keyboard (Tab key) or appropriate semantic roles, making them inaccessible for keyboard-only or screen reader users.
♿ Accessibility: Added semantic tab roles and visible focus rings to satisfy WCAG focus visibility and semantic structure requirements.
📸 Before/After: Visual focus rings now appear around active tabs when navigating via keyboard.

---
*PR created automatically by Jules for task [7622851647565905446](https://jules.google.com/task/7622851647565905446) started by @thebearwithabite*